### PR TITLE
Add GitHub action for package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish package
+
+on:
+  release:
+    types: [ published ]
+
+env:
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+jobs:
+  cargo_publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Publish to crates.io
+        run: cargo publish

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Build
-        run: cargo build --verbose
+        run: cargo build
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
-#                                           Uniswap SDK Core Rust
+# Uniswap SDK Core Rust
 
-**A Custom Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange.**
+[![Unit Tests](https://github.com/malik672/uniswap-sdk-core-rust/workflows/Rust%20Tests/badge.svg)](https://github.com/malik672/uniswap-sdk-core-rust/actions?query=workflow%3A%22Rust+Tests%22)
+[![Lint](https://github.com/malik672/uniswap-sdk-core-rust/workflows/Rust%20Linting/badge.svg)](https://github.com/malik672/uniswap-sdk-core-rust/actions?query=workflow%3A%22Rust%20Linting%22)
+[![crates.io](https://img.shields.io/crates/v/uniswap-sdk-core.svg)](https://crates.io/crates/uniswap-sdk-core)
+
+**A Custom Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized
+exchange.**
 
 > **Warning**
-> 
+>
 >   This is an custom uniswap library
 
 ## Quickstart
+
 Add this to your Cargo.toml
+
 ```
 [dependencies]
 uniswap-sdk-core = "0.6.1";
@@ -20,13 +27,15 @@ use uniswap_sdk_core::prelude::*;
 ```
 
 ## Examples
+
 The code below shows an example of how you can validate an address
+
 ```
 // The `prelude` module provides a convenient way to import a number
 // of common dependencies at once. This can be useful if you are working
 // with multiple parts of the library and want to avoid having
 // to import each dependency individually.
-use uniswap_core::prelude::*;
+use uniswap_sdk_core::prelude::*;
 
 fn main() {
         let valid_address: &str = "0x1234567890123456789012345678901234567890";
@@ -36,12 +45,15 @@ fn main() {
 
 ## Acknowledgments
 
-The Uniswap SDK Core in Rust is inspired by the original [Uniswap SDK]() and aims to provide similar functionality in the Rust programming language.
+The Uniswap SDK Core in Rust is inspired by the original [Uniswap SDK]() and aims to provide similar functionality in
+the Rust programming language.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](https://github.com/Uniswap/sdk-core/tree/main) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/Uniswap/sdk-core/tree/main) file
+for details.
 
 ## Contribution
 
-Contributions are welcome! If you find a bug or have suggestions for improvements, feel free to open an issue or submit a pull request on the [GitHub repository](https://github.com/malik672/uniswap-sdk-core-rust).
+Contributions are welcome! If you find a bug or have suggestions for improvements, feel free to open an issue or submit
+a pull request on the [GitHub repository](https://github.com/malik672/uniswap-sdk-core-rust).

--- a/src/utils/compute_price_impact.rs
+++ b/src/utils/compute_price_impact.rs
@@ -27,11 +27,9 @@ pub fn compute_price_impact<TBase: CurrencyTrait, TQuote: CurrencyTrait>(
 }
 
 #[cfg(test)]
-
 mod tests {
-    use crate::token;
-
     use super::*;
+    use crate::token;
 
     #[test]
     fn test_compute_price_impact() {


### PR DESCRIPTION
Add [`CARGO_REGISTRY_TOKEN`](https://doc.rust-lang.org/cargo/reference/config.html?highlight=CARGO_REGISTRY_TOKEN#credentials) to repo secrets before release.