### PR TITLE
Improve `BigDecimal` and `BigInt` conversion processes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -1392,7 +1392,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "uniswap-sdk-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy-primitives",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,6 @@
 use crate::prelude::*;
+use alloy_primitives::U256;
+use num_bigint::Sign;
 
 pub enum TradeType {
     ExactInput,
@@ -12,9 +14,6 @@ pub enum Rounding {
 }
 
 lazy_static! {
-    pub static ref MAX_UINT256: BigInt = BigInt::from_str_radix(
-        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-        16
-    )
-    .unwrap();
+    pub static ref MAX_UINT256: BigInt =
+        BigInt::from_bytes_be(Sign::Plus, &U256::MAX.to_be_bytes::<32>());
 }

--- a/src/entities/fractions/currency_amount.rs
+++ b/src/entities/fractions/currency_amount.rs
@@ -72,9 +72,10 @@ impl<T: CurrencyTrait> CurrencyAmount<T> {
 
     // Convert the currency amount to a string with exact precision
     pub fn to_exact(&self) -> String {
-        BigDecimal::from_str(&self.quotient().to_str_radix(10))
-            .unwrap()
-            .div(BigDecimal::from_str(&self.meta.decimal_scale.to_str_radix(10)).unwrap())
+        BigDecimal::from(self.quotient())
+            .div(BigDecimal::from(BigInt::from(
+                self.meta.decimal_scale.clone(),
+            )))
             .to_string()
     }
 

--- a/src/entities/fractions/fraction.rs
+++ b/src/entities/fractions/fraction.rs
@@ -76,9 +76,7 @@ pub trait FractionBase<M>: Sized {
 
     // Converts the fraction to a `bigdecimal::BigDecimal`
     fn to_decimal(&self) -> BigDecimal {
-        BigDecimal::from_str(&self.numerator().to_str_radix(10))
-            .unwrap()
-            .div(BigDecimal::from_str(&self.denominator().to_str_radix(10)).unwrap())
+        BigDecimal::from(self.numerator()).div(BigDecimal::from(self.denominator()))
     }
 
     // Converts the fraction to a string with a specified number of significant digits and rounding strategy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+//! # uniswap-sdk-core
+//!
+//! The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange.
+
 pub mod addresses;
 pub mod chains;
 pub mod constants;

--- a/src/utils/sqrt.rs
+++ b/src/utils/sqrt.rs
@@ -61,11 +61,7 @@ mod tests {
 
     #[test]
     fn test_sqrt_max_uint256() {
-        let max_uint256_string =
-            "115792089237316195423570985008687907853269984665640564039457584007913129639935";
-        let max_uint256 = BigInt::from_str_radix(max_uint256_string, 10).unwrap();
-        let expected_sqrt =
-            BigInt::from_str_radix("340282366920938463463374607431768211455", 10).unwrap();
-        assert_eq!(sqrt(&max_uint256).unwrap(), expected_sqrt);
+        let expected_sqrt = BigInt::from_str("340282366920938463463374607431768211455").unwrap();
+        assert_eq!(sqrt(&MAX_UINT256.clone()).unwrap(), expected_sqrt);
     }
 }


### PR DESCRIPTION
The conversion process of both `BigDecimal` and `BigInt` have been simplified by leveraging their inbuilt utility functions. Unnecessary string conversions and function calls have been removed, which improves code readability and the overall performance of the application. Also, the code includes defining `MAX_UINT256` using the `U256::MAX` module, which is more reliable and efficient. The package version is updated as part of this change.