### PR TITLE
Upgrade chain ID type to `u64`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "uniswap-sdk-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "alloy-primitives",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 
-type AddressMap = HashMap<u32, Address>;
-type ChainMap = HashMap<u32, ChainAddresses>;
-type ChainAddress = HashMap<u32, Address>;
+type AddressMap = HashMap<u64, Address>;
+type ChainMap = HashMap<u64, ChainAddresses>;
+type ChainAddress = HashMap<u64, Address>;
 
 #[derive(Clone)]
 pub struct ChainAddresses {
@@ -23,7 +23,7 @@ pub fn construct_same_address_map(address: Address, additional_networks: &[Chain
     networks.extend_from_slice(additional_networks);
     let mut map = AddressMap::new();
     for chain_id in networks {
-        map.insert(chain_id as u32, address);
+        map.insert(chain_id as u64, address);
     }
     map
 }
@@ -248,24 +248,24 @@ pub fn base_goerli_addresses() -> ChainAddresses {
 lazy_static! {
     pub static ref CHAIN_TO_ADDRESSES_MAP: ChainMap = {
         let mut new_map = ChainMap::new();
-        new_map.insert(ChainId::BNB as u32, bnb_addresses());
+        new_map.insert(ChainId::BNB as u64, bnb_addresses());
 
-        new_map.insert(ChainId::AVALANCHE as u32, avalanche_addresses());
-        new_map.insert(ChainId::MAINNET as u32, mainnet_address());
-        new_map.insert(ChainId::SEPOLIA as u32, sepolia_address());
-        new_map.insert(ChainId::GOERLI as u32, goerli_address());
-        new_map.insert(ChainId::ARBITRUMONE as u32, arbitum_one_addresses());
-        new_map.insert(ChainId::ARBITRUMGOERLI as u32, arbitrum_goerli_addresses());
-        new_map.insert(ChainId::CELO as u32, celo_addresses());
-        new_map.insert(ChainId::CELOALFAJORES as u32, celo_addresses());
+        new_map.insert(ChainId::AVALANCHE as u64, avalanche_addresses());
+        new_map.insert(ChainId::MAINNET as u64, mainnet_address());
+        new_map.insert(ChainId::SEPOLIA as u64, sepolia_address());
+        new_map.insert(ChainId::GOERLI as u64, goerli_address());
+        new_map.insert(ChainId::ARBITRUMONE as u64, arbitum_one_addresses());
+        new_map.insert(ChainId::ARBITRUMGOERLI as u64, arbitrum_goerli_addresses());
+        new_map.insert(ChainId::CELO as u64, celo_addresses());
+        new_map.insert(ChainId::CELOALFAJORES as u64, celo_addresses());
 
-        new_map.insert(ChainId::POLYGON as u32, polygon_addresses());
-        new_map.insert(ChainId::POLYGONMUMBAI as u32, polygon_addresses());
-        new_map.insert(ChainId::OPTIMISM as u32, optimism_addresses());
-        new_map.insert(ChainId::OPTIMISMGOERLI as u32, optimism_goerli_addresses());
+        new_map.insert(ChainId::POLYGON as u64, polygon_addresses());
+        new_map.insert(ChainId::POLYGONMUMBAI as u64, polygon_addresses());
+        new_map.insert(ChainId::OPTIMISM as u64, optimism_addresses());
+        new_map.insert(ChainId::OPTIMISMGOERLI as u64, optimism_goerli_addresses());
 
-        new_map.insert(ChainId::BASEGOERLI as u32, base_goerli_addresses());
-        new_map.insert(ChainId::BASE as u32, base_addresses());
+        new_map.insert(ChainId::BASEGOERLI as u64, base_goerli_addresses());
+        new_map.insert(ChainId::BASE as u64, base_addresses());
         new_map
     };
 }
@@ -275,9 +275,9 @@ pub fn v3_factory_addresses() -> ChainAddress {
     let mut chain_add = ChainAddress::new();
     for memo in SUPPORTED_CHAINS {
         chain_add.insert(
-            memo as u32,
+            memo as u64,
             CHAIN_TO_ADDRESSES_MAP
-                .get(&(memo as u32))
+                .get(&(memo as u64))
                 .unwrap()
                 .v3_core_factory_address,
         );
@@ -290,9 +290,9 @@ pub fn v3_migrator_addresses() -> ChainAddress {
     let mut chain_add = ChainAddress::new();
     for memo in SUPPORTED_CHAINS {
         chain_add.insert(
-            memo as u32,
+            memo as u64,
             CHAIN_TO_ADDRESSES_MAP
-                .get(&(memo as u32))
+                .get(&(memo as u64))
                 .unwrap()
                 .v3_migrator_address
                 .unwrap(),
@@ -306,9 +306,9 @@ pub fn multicall_addresses() -> ChainAddress {
     let mut chain_add = ChainAddress::new();
     for memo in SUPPORTED_CHAINS {
         chain_add.insert(
-            memo as u32,
+            memo as u64,
             CHAIN_TO_ADDRESSES_MAP
-                .get(&(memo as u32))
+                .get(&(memo as u64))
                 .unwrap()
                 .multicall_address,
         );
@@ -325,7 +325,7 @@ pub fn governance_alpha_v0_addresses() -> AddressMap {
 pub fn governance_alpha_v1_addresses() -> AddressMap {
     let mut new_map = AddressMap::new();
     new_map.insert(
-        ChainId::MAINNET as u32,
+        ChainId::MAINNET as u64,
         address!("C4e172459f1E7939D522503B81AFAaC1014CE6F6"),
     );
     new_map
@@ -335,7 +335,7 @@ pub fn governance_alpha_v1_addresses() -> AddressMap {
 pub fn governance_bravo_addresses() -> AddressMap {
     let mut new_map = AddressMap::new();
     new_map.insert(
-        ChainId::MAINNET as u32,
+        ChainId::MAINNET as u64,
         address!("408ED6354d4973f66138C91495F2f2FCbd8724C3"),
     );
     new_map
@@ -348,7 +348,7 @@ pub fn timelock_addresses() -> AddressMap {
 pub fn merkle_distributor_address() -> AddressMap {
     let mut new_map = AddressMap::new();
     new_map.insert(
-        ChainId::MAINNET as u32,
+        ChainId::MAINNET as u64,
         address!("090D4613473dEE047c3f2706764f49E0821D256e"),
     );
     new_map
@@ -357,7 +357,7 @@ pub fn merkle_distributor_address() -> AddressMap {
 pub fn argent_wallet_detector_address() -> AddressMap {
     let mut new_map = AddressMap::new();
     new_map.insert(
-        ChainId::MAINNET as u32,
+        ChainId::MAINNET as u64,
         address!("eca4B0bDBf7c55E9b7925919d03CbF8Dc82537E8"),
     );
     new_map
@@ -367,9 +367,9 @@ pub fn quoter_address() -> ChainAddress {
     let mut chain_add = ChainAddress::new();
     for memo in SUPPORTED_CHAINS {
         chain_add.insert(
-            memo as u32,
+            memo as u64,
             CHAIN_TO_ADDRESSES_MAP
-                .get(&(memo as u32))
+                .get(&(memo as u64))
                 .unwrap()
                 .quoter_address,
         );
@@ -381,15 +381,15 @@ pub fn nonfungible_position_manager_address() -> ChainAddress {
     let mut chain_add = ChainAddress::new();
     for memo in SUPPORTED_CHAINS {
         if CHAIN_TO_ADDRESSES_MAP
-            .get(&(memo as u32))
+            .get(&(memo as u64))
             .unwrap()
             .nonfungible_position_manager_address
             .is_some()
         {
             chain_add.insert(
-                memo as u32,
+                memo as u64,
                 CHAIN_TO_ADDRESSES_MAP
-                    .get(&(memo as u32))
+                    .get(&(memo as u64))
                     .unwrap()
                     .nonfungible_position_manager_address
                     .unwrap(),
@@ -406,7 +406,7 @@ pub fn ens_resgister_address_map() -> AddressMap {
 pub fn socks_controller_addresses() -> AddressMap {
     let mut new_map = AddressMap::new();
     new_map.insert(
-        ChainId::MAINNET as u32,
+        ChainId::MAINNET as u64,
         address!("65770b5283117639760beA3F867b69b3697a91dd"),
     );
     new_map
@@ -416,15 +416,15 @@ pub fn tick_lens_addresses() -> ChainAddress {
     let mut chain_add = ChainAddress::new();
     for memo in SUPPORTED_CHAINS {
         if CHAIN_TO_ADDRESSES_MAP
-            .get(&(memo as u32))
+            .get(&(memo as u64))
             .unwrap()
             .tick_lens_address
             .is_some()
         {
             chain_add.insert(
-                memo as u32,
+                memo as u64,
                 CHAIN_TO_ADDRESSES_MAP
-                    .get(&(memo as u32))
+                    .get(&(memo as u64))
                     .unwrap()
                     .tick_lens_address
                     .unwrap(),
@@ -438,15 +438,15 @@ pub fn v1_mixed_route_quoter_address() -> ChainAddress {
     let mut chain_add = ChainAddress::new();
     for memo in SUPPORTED_CHAINS {
         if CHAIN_TO_ADDRESSES_MAP
-            .get(&(memo as u32))
+            .get(&(memo as u64))
             .unwrap()
             .v1_mixed_route_quoter_address
             .is_some()
         {
             chain_add.insert(
-                memo as u32,
+                memo as u64,
                 CHAIN_TO_ADDRESSES_MAP
-                    .get(&(memo as u32))
+                    .get(&(memo as u64))
                     .unwrap()
                     .v1_mixed_route_quoter_address
                     .unwrap(),
@@ -456,8 +456,8 @@ pub fn v1_mixed_route_quoter_address() -> ChainAddress {
     chain_add
 }
 
-pub fn swap_router02_address(chain_id: u32) -> Address {
-    if chain_id == ChainId::BNB as u32 {
+pub fn swap_router02_address(chain_id: u64) -> Address {
+    if chain_id == ChainId::BNB as u64 {
         CHAIN_TO_ADDRESSES_MAP
             .get(&chain_id)
             .unwrap()

--- a/src/entities/base_currency.rs
+++ b/src/entities/base_currency.rs
@@ -1,6 +1,8 @@
+use alloy_primitives::ChainId;
+
 #[derive(Clone, PartialEq, Debug)]
 pub struct CurrencyLike<M> {
-    pub chain_id: u32,
+    pub chain_id: ChainId,
     pub decimals: u8,
     pub symbol: Option<String>,
     pub name: Option<String>,
@@ -10,7 +12,7 @@ pub struct CurrencyLike<M> {
 /// A currency is any fungible financial instrument, including Ether, all ERC20 tokens, and other chain-native currencies
 pub trait BaseCurrency: Clone {
     /// The chain ID on which this currency resides
-    fn chain_id(&self) -> u32;
+    fn chain_id(&self) -> ChainId;
 
     /// The decimals used in representing currency amounts
     fn decimals(&self) -> u8;
@@ -24,7 +26,7 @@ pub trait BaseCurrency: Clone {
 
 // Implementation of methods for CurrencyLike
 impl<M: Clone> BaseCurrency for CurrencyLike<M> {
-    fn chain_id(&self) -> u32 {
+    fn chain_id(&self) -> ChainId {
         self.chain_id
     }
 

--- a/src/entities/currency.rs
+++ b/src/entities/currency.rs
@@ -56,7 +56,7 @@ impl CurrencyTrait for Currency {
 }
 
 impl BaseCurrency for Currency {
-    fn chain_id(&self) -> u32 {
+    fn chain_id(&self) -> u64 {
         match self {
             Currency::NativeCurrency(native_currency) => native_currency.chain_id(),
             Currency::Token(token) => token.chain_id(),

--- a/src/entities/ether.rs
+++ b/src/entities/ether.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 // Lazy static cache for Ether instances
 lazy_static! {
-    static ref ETHER_CACHE: Mutex<HashMap<u32, Ether>> = Mutex::new(HashMap::new());
+    static ref ETHER_CACHE: Mutex<HashMap<u64, Ether>> = Mutex::new(HashMap::new());
 }
 
 /// Ether is the main usage of a 'native' currency, i.e., for Ethereum mainnet and all testnets.
@@ -41,7 +41,7 @@ impl CurrencyTrait for Ether {
 /// Implementation of additional methods for the `Ether` type.
 impl Ether {
     /// Creates a new instance of `Ether` with the specified chain ID.
-    pub fn new(chain_id: u32) -> Self {
+    pub fn new(chain_id: u64) -> Self {
         Self {
             chain_id,
             decimals: 18,
@@ -52,7 +52,7 @@ impl Ether {
     }
 
     /// Retrieves or creates an `Ether` instance for the specified chain ID.
-    pub fn on_chain(chain_id: u32) -> Self {
+    pub fn on_chain(chain_id: u64) -> Self {
         let mut cache = ETHER_CACHE.lock().unwrap();
         match cache.get(&chain_id) {
             Some(ether) => ether.clone(),
@@ -71,12 +71,12 @@ mod tests {
 
     #[test]
     fn test_static_constructor_uses_cache() {
-        assert!(Ether::on_chain(1) == Ether::on_chain(1));
+        assert_eq!(Ether::on_chain(1), Ether::on_chain(1));
     }
 
     #[test]
     fn test_caches_once_per_chain_id() {
-        assert!(Ether::on_chain(1) != Ether::on_chain(2));
+        assert_ne!(Ether::on_chain(1), Ether::on_chain(2));
     }
 
     #[test]

--- a/src/entities/token.rs
+++ b/src/entities/token.rs
@@ -42,7 +42,7 @@ impl CurrencyTrait for Token {
 
 impl Token {
     pub fn new(
-        chain_id: u32,
+        chain_id: u64,
         address: String,
         decimals: u8,
         symbol: Option<String>,

--- a/src/entities/weth9.rs
+++ b/src/entities/weth9.rs
@@ -5,7 +5,7 @@ use crate::{prelude::*, token};
 #[derive(Clone, PartialEq, Debug)]
 pub struct WETH9 {
     /// A mapping of chain IDs to corresponding WETH tokens.
-    tokens: HashMap<u32, Token>,
+    tokens: HashMap<u64, Token>,
 }
 
 /// Default implementation for `WETH9`, creating an instance with predefined WETH tokens on various chains.
@@ -162,7 +162,7 @@ impl WETH9 {
     /// * `chain_id`: The chain ID for which to retrieve the WETH token.
     ///
     /// Returns: `Some(Token)` if the token exists, `None` otherwise.
-    pub fn get(&self, chain_id: u32) -> Option<&Token> {
+    pub fn get(&self, chain_id: u64) -> Option<&Token> {
         self.tokens.get(&chain_id)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Chain IDs do not match: {0} and {1}")]
-    ChainIdMismatch(u32, u32),
+    ChainIdMismatch(u64, u64),
 
     #[error("Addresses are equal")]
     EqualAddresses,


### PR DESCRIPTION
The data type of chain IDs has been changed from `u32` to `u64` across various components of the application, offering a wider range for chain IDs. The updates have been performed in `src/error.rs`, `src/entities/currency.rs`, `src/entities/weth9.rs`, `src/addresses.rs`, `src/entities/base_currency.rs`, `src/entities/token.rs`, `src/entities/ether.rs`, and a few other places. The library version has been updated in `Cargo.lock` and `Cargo.toml` to reflect the change.