### PR TITLE
chore(refactor): Access fields directly instead of through `meta`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"

--- a/src/entities/fractions/currency_amount.rs
+++ b/src/entities/fractions/currency_amount.rs
@@ -56,7 +56,7 @@ impl<T: CurrencyTrait> CurrencyAmount<T> {
     pub fn multiply<M>(&self, other: &impl FractionBase<M>) -> Result<Self, Error> {
         let multiplied = self.as_fraction() * other.as_fraction();
         Self::from_fractional_amount(
-            self.meta.currency.clone(),
+            self.currency.clone(),
             multiplied.numerator(),
             multiplied.denominator(),
         )
@@ -66,7 +66,7 @@ impl<T: CurrencyTrait> CurrencyAmount<T> {
     pub fn divide<M>(&self, other: &impl FractionBase<M>) -> Result<Self, Error> {
         let divided = self.as_fraction() / other.as_fraction();
         Self::from_fractional_amount(
-            self.meta.currency.clone(),
+            self.currency.clone(),
             divided.numerator(),
             divided.denominator(),
         )
@@ -75,20 +75,18 @@ impl<T: CurrencyTrait> CurrencyAmount<T> {
     /// Convert the currency amount to a string with exact precision
     pub fn to_exact(&self) -> String {
         BigDecimal::from(self.quotient())
-            .div(BigDecimal::from(BigInt::from(
-                self.meta.decimal_scale.clone(),
-            )))
+            .div(BigDecimal::from(BigInt::from(self.decimal_scale.clone())))
             .to_string()
     }
 
     /// Addition of another currency amount to the current amount
     pub fn add(&self, other: &Self) -> Result<Self, Error> {
-        if !self.meta.currency.equals(&other.meta.currency) {
+        if !self.currency.equals(&other.currency) {
             return Err(Error::NotEqual());
         }
         let added = self.as_fraction() + other.as_fraction();
         Self::from_fractional_amount(
-            self.meta.currency.clone(),
+            self.currency.clone(),
             added.numerator(),
             added.denominator(),
         )
@@ -96,12 +94,12 @@ impl<T: CurrencyTrait> CurrencyAmount<T> {
 
     /// Subtraction of another currency amount from the current amount
     pub fn subtract(&self, other: &Self) -> Result<Self, Error> {
-        if !self.meta.currency.equals(&other.meta.currency) {
+        if !self.currency.equals(&other.currency) {
             return Err(Error::NotEqual());
         }
         let subtracted = self.as_fraction() - other.as_fraction();
         Self::from_fractional_amount(
-            self.meta.currency.clone(),
+            self.currency.clone(),
             subtracted.numerator(),
             subtracted.denominator(),
         )
@@ -113,18 +111,18 @@ impl<T: CurrencyTrait> CurrencyAmount<T> {
         significant_digits: u8,
         rounding: Rounding,
     ) -> Result<String, Error> {
-        (self.as_fraction() / Fraction::new(self.meta.decimal_scale.clone(), 1))
+        (self.as_fraction() / Fraction::new(self.decimal_scale.clone(), 1))
             .to_significant(significant_digits, rounding)
     }
 
     /// Convert the currency amount to a string with a fixed number of decimal places
     pub fn to_fixed(&self, decimal_places: u8, rounding: Rounding) -> Result<String, Error> {
-        if !decimal_places <= self.meta.currency.decimals() {
+        if !decimal_places <= self.currency.decimals() {
             return Err(Error::NotEqual());
         }
 
         Ok(
-            (self.as_fraction() / Fraction::new(self.meta.decimal_scale.clone(), 1))
+            (self.as_fraction() / Fraction::new(self.decimal_scale.clone(), 1))
                 .to_fixed(decimal_places, rounding),
         )
     }
@@ -135,7 +133,7 @@ impl<T: CurrencyTrait> CurrencyAmount<T> {
     /// Wrap the currency amount if the currency is not native
     pub fn wrapped(&self) -> Result<CurrencyAmount<Token>, Error> {
         CurrencyAmount::from_fractional_amount(
-            self.meta.currency.wrapped(),
+            self.currency.wrapped(),
             self.numerator(),
             self.denominator(),
         )
@@ -179,10 +177,7 @@ mod tests {
         let amount =
             CurrencyAmount::from_raw_amount(Currency::NativeCurrency(ether.clone()), 100).unwrap();
         assert_eq!(amount.quotient(), 100.into());
-        assert!(amount
-            .meta
-            .currency
-            .equals(&Currency::NativeCurrency(ether)));
+        assert!(amount.currency.equals(&Currency::NativeCurrency(ether)));
     }
 
     #[test]

--- a/src/entities/fractions/price.rs
+++ b/src/entities/fractions/price.rs
@@ -62,8 +62,8 @@ where
     /// Flip the price, switching the base and quote currency
     pub fn invert(&self) -> Price<TQuote, TBase> {
         Price::new(
-            self.meta.quote_currency.clone(),
-            self.meta.base_currency.clone(),
+            self.quote_currency.clone(),
+            self.base_currency.clone(),
             self.numerator().clone(),
             self.denominator().clone(),
         )
@@ -75,14 +75,14 @@ where
         &self,
         other: &Price<TQuote, TOtherQuote>,
     ) -> Result<Price<TBase, TOtherQuote>, Error> {
-        if !self.meta.quote_currency.equals(&other.meta.base_currency) {
+        if !self.quote_currency.equals(&other.base_currency) {
             return Err(Error::NotEqual());
         }
 
         let fraction = self.as_fraction() * other.as_fraction();
         Ok(Price::new(
-            self.meta.base_currency.clone(),
-            other.meta.quote_currency.clone(),
+            self.base_currency.clone(),
+            other.quote_currency.clone(),
             fraction.denominator().clone(),
             fraction.numerator().clone(),
         ))
@@ -93,16 +93,12 @@ where
         &self,
         currency_amount: CurrencyAmount<TBase>,
     ) -> Result<CurrencyAmount<TQuote>, Error> {
-        if !currency_amount
-            .meta
-            .currency
-            .equals(&self.meta.base_currency)
-        {
+        if !currency_amount.currency.equals(&self.base_currency) {
             return Err(Error::NotEqual());
         }
         let fraction = self.as_fraction() * currency_amount.as_fraction();
         CurrencyAmount::from_fractional_amount(
-            self.meta.quote_currency.clone(),
+            self.quote_currency.clone(),
             fraction.numerator().clone(),
             fraction.denominator().clone(),
         )
@@ -110,7 +106,7 @@ where
 
     /// Get the value scaled by decimals for formatting
     pub fn adjusted_for_decimals(&self) -> Fraction {
-        self.as_fraction() * self.meta.scalar.clone()
+        self.as_fraction() * self.scalar.clone()
     }
 
     /// Converts the adjusted price to a string with a specified number of significant digits and rounding strategy
@@ -151,8 +147,8 @@ mod test {
             price.to_significant(5, Rounding::RoundDown).unwrap(),
             "54321"
         );
-        assert!(price.clone().meta.base_currency.equals(&TOKEN0.clone()));
-        assert!(price.clone().meta.quote_currency.equals(&TOKEN1.clone()));
+        assert!(price.clone().base_currency.equals(&TOKEN0.clone()));
+        assert!(price.clone().quote_currency.equals(&TOKEN1.clone()));
     }
 
     #[test]
@@ -165,8 +161,8 @@ mod test {
             price.to_significant(5, Rounding::RoundDown).unwrap(),
             "54321"
         );
-        assert!(price.clone().meta.base_currency.equals(&TOKEN0.clone()));
-        assert!(price.clone().meta.quote_currency.equals(&TOKEN1.clone()));
+        assert!(price.clone().base_currency.equals(&TOKEN0.clone()));
+        assert!(price.clone().quote_currency.equals(&TOKEN1.clone()));
     }
 
     #[test]

--- a/src/entities/token.rs
+++ b/src/entities/token.rs
@@ -16,7 +16,7 @@ impl CurrencyTrait for Token {
     }
 
     fn address(&self) -> Address {
-        self.meta.address
+        self.address
     }
 
     /// Returns true if the two tokens are equivalent, i.e. have the same chainId and address.


### PR DESCRIPTION
In the previous setup, several fields in different structs were accessed through the `meta` field, introducing unnecessary dependencies. This commit refactors those instances to directly access the fields, thereby simplifying code readability and maintainability. The impacted structs include `token`, `currency_amount`, and `price` within `token.rs`, `currency_amount.rs`, and `price.rs` respectively. The version number is also incremented in `Cargo.toml` from 0.16.0 to 0.16.1.