### PR TITLE
feat(macro): Update token macro and fix address formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"

--- a/src/entities/token.rs
+++ b/src/entities/token.rs
@@ -86,12 +86,34 @@ impl Token {
 /// Shorthand macro to create a token
 #[macro_export]
 macro_rules! token {
+    ($chain_id:expr, $address:literal, $decimals:expr) => {
+        Token::new(
+            $chain_id,
+            address!($address),
+            $decimals,
+            None,
+            None,
+            None,
+            None,
+        )
+    };
     ($chain_id:expr, $address:expr, $decimals:expr) => {
         Token::new(
             $chain_id,
-            $address.parse::<Address>().unwrap(),
+            $address.to_string().parse::<Address>().unwrap(),
             $decimals,
             None,
+            None,
+            None,
+            None,
+        )
+    };
+    ($chain_id:expr, $address:literal, $decimals:expr, $symbol:expr) => {
+        Token::new(
+            $chain_id,
+            address!($address),
+            $decimals,
+            Some($symbol.to_string()),
             None,
             None,
             None,
@@ -100,7 +122,7 @@ macro_rules! token {
     ($chain_id:expr, $address:expr, $decimals:expr, $symbol:expr) => {
         Token::new(
             $chain_id,
-            $address.parse::<Address>().unwrap(),
+            $address.to_string().parse::<Address>().unwrap(),
             $decimals,
             Some($symbol.to_string()),
             None,
@@ -108,10 +130,21 @@ macro_rules! token {
             None,
         )
     };
+    ($chain_id:expr, $address:literal, $decimals:expr, $symbol:expr, $name:expr) => {
+        Token::new(
+            $chain_id,
+            address!($address),
+            $decimals,
+            Some($symbol.to_string()),
+            Some($name.to_string()),
+            None,
+            None,
+        )
+    };
     ($chain_id:expr, $address:expr, $decimals:expr, $symbol:expr, $name:expr) => {
         Token::new(
             $chain_id,
-            $address.parse::<Address>().unwrap(),
+            $address.to_string().parse::<Address>().unwrap(),
             $decimals,
             Some($symbol.to_string()),
             Some($name.to_string()),

--- a/src/entities/weth9.rs
+++ b/src/entities/weth9.rs
@@ -25,7 +25,7 @@ impl WETH9 {
             1,
             token!(
                 1,
-                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -35,7 +35,7 @@ impl WETH9 {
             3,
             token!(
                 3,
-                "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+                "c778417E063141139Fce010982780140Aa0cD5Ab",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -45,7 +45,7 @@ impl WETH9 {
             4,
             token!(
                 4,
-                "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+                "c778417E063141139Fce010982780140Aa0cD5Ab",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -55,7 +55,7 @@ impl WETH9 {
             5,
             token!(
                 5,
-                "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+                "B4FBF271143F4FBf7B91A5ded31805e42b2208d6",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -65,7 +65,7 @@ impl WETH9 {
             42,
             token!(
                 42,
-                "0xd0A1E359811322d97991E03f863a0C30C2cF029C",
+                "d0A1E359811322d97991E03f863a0C30C2cF029C",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -75,7 +75,7 @@ impl WETH9 {
             10,
             token!(
                 10,
-                "0x4200000000000000000000000000000000000006",
+                "4200000000000000000000000000000000000006",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -85,7 +85,7 @@ impl WETH9 {
             69,
             token!(
                 69,
-                "0x4200000000000000000000000000000000000006",
+                "4200000000000000000000000000000000000006",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -95,7 +95,7 @@ impl WETH9 {
             42161,
             token!(
                 42161,
-                "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+                "82aF49447D8a07e3bd95BD0d56f35241523fBab1",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -105,7 +105,7 @@ impl WETH9 {
             421611,
             token!(
                 421611,
-                "0xB47e6A5f8b33b3F17603C83a0535A9dcD7E32681",
+                "B47e6A5f8b33b3F17603C83a0535A9dcD7E32681",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -115,7 +115,7 @@ impl WETH9 {
             8453,
             token!(
                 8453,
-                "0x4200000000000000000000000000000000000006",
+                "4200000000000000000000000000000000000006",
                 18,
                 "WETH",
                 "Wrapped Ether"
@@ -125,7 +125,7 @@ impl WETH9 {
             56,
             token!(
                 56,
-                "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+                "bb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
                 18,
                 "WBNB",
                 "Wrapped BNB"
@@ -135,7 +135,7 @@ impl WETH9 {
             137,
             token!(
                 137,
-                "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+                "0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
                 18,
                 "WMATIC",
                 "Wrapped MATIC"
@@ -145,7 +145,7 @@ impl WETH9 {
             43114,
             token!(
                 43114,
-                "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+                "B31f66AA3C1e785363F0875A1B74E27b85FD66c7",
                 18,
                 "WAVAX",
                 "Wrapped AVAX"


### PR DESCRIPTION
The token macro in `src/entities/token.rs` has been updated to create tokens with more levels of specificity based on the passed arguments. This includes creating tokens with only chain_id, address, and decimals, as well as tokens with additional symbol and name parameters. The address formatting in `src/entities/weth9.rs` is modified to remove leading zeroes for clearer representation. Also, the package is bumped to version `0.17.1` in `Cargo.toml` due to these changes.