### PR TITLE
chore: Update GitHub Actions and dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,8 +30,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-registry-
 
-      - name: Use nightly toolchain
-        run: rustup override set nightly
+      - name: Install Rust toolchain via rustup
+        run: |
+          rustup override set nightly
+          rustup component add clippy --toolchain nightly
 
       - name: Check lint
         run: cargo clippy -- -D warnings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           rustup override set nightly
           rustup component add clippy --toolchain nightly
+          rustup component add rustfmt --toolchain nightly
 
       - name: Check lint
         run: cargo clippy -- -D warnings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -30,13 +30,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-registry-
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
+      - name: Use nightly toolchain
+        run: rustup override set nightly
 
       - name: Check lint
         run: cargo clippy -- -D warnings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "uniswap-sdk-core"
-version = "0.20.1"
+version = "0.21.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
 license = "MIT"
 
 [dependencies]
-alloy-primitives = "0.6"
+alloy-primitives = "0.7"
 bigdecimal = "=0.4.2"
 eth_checksum = { version = "0.1.2", optional = true }
 lazy_static = "1.4"


### PR DESCRIPTION
The commit updates the used GitHub Actions to their latest versions. Specifically, it modifies the workflow files (publish.yml, rust.yml, lint.yml) to use actions/checkout@v4 and actions/cache@v4. Additionally, it simplifies the Rust toolchain setup in the lint workflow to just set the nightly toolchain override.