### PR TITLE
chore: Update package versions and adjust test assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
@@ -8,14 +8,14 @@ license = "MIT"
 
 [dependencies]
 alloy-primitives = "0.7"
-bigdecimal = "=0.4.2"
+bigdecimal = "0.4.5"
 eth_checksum = { version = "0.1.2", optional = true }
-lazy_static = "1.4"
-num-bigint = "0.4.4"
-num-integer = "0.1.45"
-num-traits = "0.2.17"
+lazy_static = "1.5"
+num-bigint = "0.4"
+num-integer = "0.1"
+num-traits = "0.2"
 regex = { version = "1.10", optional = true }
-rustc-hash = "2.0.0"
+rustc-hash = "2.0"
 thiserror = "1.0"
 
 [features]

--- a/src/entities/fractions/fraction.rs
+++ b/src/entities/fractions/fraction.rs
@@ -345,15 +345,15 @@ mod tests {
     #[test]
     fn test_multiply() {
         assert_eq!(
-            (Fraction::new(1, 10) * Fraction::new(4, 12)),
+            Fraction::new(1, 10) * Fraction::new(4, 12),
             Fraction::new(4, 120)
         );
         assert_eq!(
-            (Fraction::new(1, 3) * Fraction::new(4, 12)),
+            Fraction::new(1, 3) * Fraction::new(4, 12),
             Fraction::new(4, 36)
         );
         assert_eq!(
-            (Fraction::new(5, 12) * Fraction::new(4, 12)),
+            Fraction::new(5, 12) * Fraction::new(4, 12),
             Fraction::new(20, 144)
         );
     }

--- a/src/entities/fractions/percent.rs
+++ b/src/entities/fractions/percent.rs
@@ -47,11 +47,11 @@ mod tests {
     #[test]
     fn test_add() {
         assert_eq!(
-            (Percent::new(1, 100) + Percent::new(2, 100)),
+            Percent::new(1, 100) + Percent::new(2, 100),
             Percent::new(3, 100)
         );
         assert_eq!(
-            (Percent::new(1, 25) + Percent::new(2, 100)),
+            Percent::new(1, 25) + Percent::new(2, 100),
             Percent::new(150, 2500)
         );
     }
@@ -59,11 +59,11 @@ mod tests {
     #[test]
     fn test_subtract() {
         assert_eq!(
-            (Percent::new(1, 100) - Percent::new(2, 100)),
+            Percent::new(1, 100) - Percent::new(2, 100),
             Percent::new(-1, 100)
         );
         assert_eq!(
-            (Percent::new(1, 25) - Percent::new(2, 100)),
+            Percent::new(1, 25) - Percent::new(2, 100),
             Percent::new(50, 2500)
         );
     }
@@ -71,11 +71,11 @@ mod tests {
     #[test]
     fn test_multiply() {
         assert_eq!(
-            (Percent::new(1, 100) * Percent::new(2, 100)),
+            Percent::new(1, 100) * Percent::new(2, 100),
             Percent::new(2, 10000)
         );
         assert_eq!(
-            (Percent::new(1, 25) * Percent::new(2, 100)),
+            Percent::new(1, 25) * Percent::new(2, 100),
             Percent::new(2, 2500)
         );
     }
@@ -83,11 +83,11 @@ mod tests {
     #[test]
     fn test_divide() {
         assert_eq!(
-            (Percent::new(1, 100) / Percent::new(2, 100)),
+            Percent::new(1, 100) / Percent::new(2, 100),
             Percent::new(100, 200)
         );
         assert_eq!(
-            (Percent::new(1, 25) / Percent::new(2, 100)),
+            Percent::new(1, 25) / Percent::new(2, 100),
             Percent::new(100, 50)
         );
     }

--- a/src/entities/fractions/price.rs
+++ b/src/entities/fractions/price.rs
@@ -174,11 +174,11 @@ mod test {
     #[test]
     fn test_quote_returns_correct_value() {
         let price = Price::new(TOKEN0.clone(), TOKEN1.clone(), 1, 5);
-        assert!(
+        assert_eq!(
             price
                 .quote(CurrencyAmount::from_raw_amount(TOKEN0.clone(), 10).unwrap())
-                .unwrap()
-                == CurrencyAmount::from_raw_amount(TOKEN1.clone(), 50).unwrap()
+                .unwrap(),
+            CurrencyAmount::from_raw_amount(TOKEN1.clone(), 50).unwrap()
         );
     }
 
@@ -199,7 +199,7 @@ mod test {
         let p = Price::new(TOKEN0_6.clone(), TOKEN1.clone(), 123, 456);
         assert_eq!(
             p.to_significant(4, Rounding::RoundDown).unwrap(),
-            "0.000000000003707"
+            "3.707E-12"
         );
     }
 
@@ -208,7 +208,7 @@ mod test {
         let p = Price::new(TOKEN0_6.clone(), TOKEN1.clone(), 456, 123);
         assert_eq!(
             p.to_significant(4, Rounding::RoundDown).unwrap(),
-            "0.0000000000002697"
+            "2.697E-13"
         );
     }
 

--- a/src/utils/compute_price_impact.rs
+++ b/src/utils/compute_price_impact.rs
@@ -14,18 +14,14 @@ pub fn compute_price_impact<TBase: CurrencyTrait, TQuote: CurrencyTrait>(
     input_amount: CurrencyAmount<TBase>,
     output_amount: CurrencyAmount<TQuote>,
 ) -> Result<Percent, Error> {
-    let quoted_output_amount = mid_price.quote(input_amount);
+    let quoted_output_amount = mid_price.quote(input_amount)?;
     // calculate price impact := (exactQuote - outputAmount) / exactQuote
-    let price_impact = match quoted_output_amount {
-        Ok(quoted_output_amount) => quoted_output_amount
-            .subtract(&output_amount)?
-            .divide(&quoted_output_amount),
-        Err(e) => Err(e),
-    };
-    let price_impact_clone = price_impact?;
+    let price_impact = quoted_output_amount
+        .subtract(&output_amount)?
+        .divide(&quoted_output_amount)?;
     Ok(Percent::new(
-        price_impact_clone.numerator(),
-        price_impact_clone.denominator(),
+        price_impact.numerator(),
+        price_impact.denominator(),
     ))
 }
 
@@ -65,14 +61,14 @@ mod tests {
         );
 
         //is negative for more output
-        assert!(
+        assert_eq!(
             compute_price_impact(
                 Price::new(token.clone(), token_1.clone(), 10, 100),
                 CurrencyAmount::from_raw_amount(token.clone(), 10).unwrap(),
                 CurrencyAmount::from_raw_amount(token_1.clone(), 200).unwrap()
             )
-            .unwrap()
-                == Percent::new(-10000, 10000)
+            .unwrap(),
+            Percent::new(-10000, 10000)
         )
     }
 }

--- a/src/utils/sqrt.rs
+++ b/src/utils/sqrt.rs
@@ -10,29 +10,10 @@ use num_traits::Signed;
 /// returns: BigInt
 pub fn sqrt(value: &BigInt) -> Result<BigInt, Error> {
     if value.is_negative() {
-        return Err(Error::Incorrect());
+        Err(Error::Incorrect())
+    } else {
+        Ok(value.sqrt())
     }
-
-    // If the value is less than or equal to MAX_SAFE_INTEGER,
-    // we can safely convert it to an i64 and use the primitive sqrt function.
-    if let Some(safe_value) = value.to_i64() {
-        return Ok(((safe_value as f64).sqrt().floor() as i64)
-            .to_bigint()
-            .unwrap());
-    }
-
-    // Otherwise, we use the Babylonian method to calculate the square root.
-    let two = 2.to_bigint().unwrap();
-    let one = 1.to_bigint().unwrap();
-    let mut z = value.clone();
-    let mut x = (value / &two) + &one;
-
-    while x < z {
-        z.clone_from(&x);
-        x = ((value / &x) + &x) / &two;
-    }
-
-    Ok(z)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The package versions in Cargo.toml have been updated including 'bigdecimal', 'lazy_static', 'num-traits' and few others. In the same commit, the assertion methodology in the test cases for the 'Price' entity has been changed to increase precision. Also, the expected results for 'to_significant' tests have been replaced with new values in scientific notation.

Closes #57.