### PR TITLE
feat: Migrate to `no_std`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,4 +34,4 @@ jobs:
         run: cargo build
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
@@ -16,9 +16,10 @@ num-integer = "0.1"
 num-traits = "0.2"
 regex = { version = "1.10", optional = true }
 rustc-hash = "2.0"
-thiserror = "1.0"
+thiserror = { version = "1.0", optional = true }
 
 [features]
+std = ["thiserror"]
 validate_parse_address = ["eth_checksum", "regex"]
 
 [lib]

--- a/src/entities/base_currency.rs
+++ b/src/entities/base_currency.rs
@@ -1,6 +1,5 @@
-use std::ops::Deref;
-
 use alloy_primitives::ChainId;
+use crate::prelude::*;
 
 /// `CurrencyLike` is a generic struct representing a currency with a specific chain ID,
 /// decimals, symbol, name, and additional metadata.

--- a/src/entities/base_currency.rs
+++ b/src/entities/base_currency.rs
@@ -1,5 +1,5 @@
-use alloy_primitives::ChainId;
 use crate::prelude::*;
+use alloy_primitives::ChainId;
 
 /// `CurrencyLike` is a generic struct representing a currency with a specific chain ID,
 /// decimals, symbol, name, and additional metadata.

--- a/src/entities/ether.rs
+++ b/src/entities/ether.rs
@@ -1,10 +1,5 @@
 use crate::prelude::*;
 
-// Lazy static cache for Ether instances
-lazy_static! {
-    static ref ETHER_CACHE: Mutex<FxHashMap<u64, Ether>> = Mutex::new(FxHashMap::default());
-}
-
 /// Ether is the main usage of a 'native' currency, i.e., for Ethereum mainnet and all testnets.
 /// Represents the native currency of the blockchain.
 pub type Ether = CurrencyLike<()>;
@@ -51,15 +46,7 @@ impl Ether {
 
     /// Retrieves or creates an [`Ether`] instance for the specified chain ID.
     pub fn on_chain(chain_id: u64) -> Self {
-        let mut cache = ETHER_CACHE.lock().unwrap();
-        match cache.get(&chain_id) {
-            Some(ether) => ether.clone(),
-            None => {
-                let ether = Ether::new(chain_id);
-                cache.insert(chain_id, ether.clone());
-                ether
-            }
-        }
+        Self::new(chain_id)
     }
 }
 

--- a/src/entities/fractions/fraction.rs
+++ b/src/entities/fractions/fraction.rs
@@ -1,6 +1,6 @@
 /// External crate dependencies
 use crate::prelude::*;
-use std::ops::{Add, Deref, Mul, Sub};
+use core::ops::{Add, Deref, Mul, Sub};
 
 /// Struct representing a fraction with metadata
 #[derive(Clone, Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
     Incorrect(),
 }
 
-#[cfg(test)]
+#[cfg(any(feature = "std", test))]
 mod tests {
     use super::*;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,26 +1,25 @@
-use crate::prelude::*;
-
 /// Represents errors that can occur in the context of currency operations.
-#[derive(Debug, Error, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum Error {
-    /// Triggers when compared Chain Ids do not match
-    #[error("Chain IDs do not match: {0} and {1}")]
+    /// Triggers when the compared chain ids do not match
+    #[cfg_attr(feature = "std", error("Chain IDs do not match: {0} and {1}"))]
     ChainIdMismatch(u64, u64),
 
-    /// Triggers when comapred addresses are the smae
-    #[error("Addresses are equal")]
+    /// Triggers when compared addresses are the same
+    #[cfg_attr(feature = "std", error("Addresses are equal"))]
     EqualAddresses,
 
     /// Triggers when it tries to exceed the max uint
-    #[error("amount has exceeded MAX_UINT256")]
+    #[cfg_attr(feature = "std", error("amount has exceeded MAX_UINT256"))]
     MaxUint,
 
     ///Triggers when the Compared values are not equal
-    #[error("not equal")]
+    #[cfg_attr(feature = "std", error("not equal"))]
     NotEqual(),
 
-    /// Triggers when The value is inccorrrect
-    #[error("incorrect")]
+    /// Triggers when The value is incorrect
+    #[cfg_attr(feature = "std", error("incorrect"))]
     Incorrect(),
 }
 

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -1,2 +1,1 @@
-///token example
 pub mod token_example;

--- a/src/examples/token_example.rs
+++ b/src/examples/token_example.rs
@@ -1,4 +1,4 @@
-// token_example.rs
+#![cfg(test)]
 
 // Import the Token struct from the Uniswap SDK-Core
 use crate::entities::token::Token;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap
 //! decentralized exchange.
+//! #![cfg_attr(not(test), no_std)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,
@@ -12,6 +13,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+extern crate alloc;
 
 /// Contains functionality related to All Contracts deployed and supported by the Uniswap SDK.
 pub mod addresses;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap
 //! decentralized exchange.
-//! #![cfg_attr(not(test), no_std)]
+//!
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap
 //! decentralized exchange.
-//!
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![warn(
     missing_copy_implementations,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -31,4 +31,3 @@ pub use num_bigint::{BigInt, BigUint, ToBigInt, ToBigUint};
 pub use num_integer::Integer;
 pub use num_traits::{Num, ToPrimitive, Zero};
 pub use rustc_hash::FxHashMap;
-pub use thiserror::Error;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,12 +17,18 @@ pub use crate::{
     error::Error,
     utils::*,
 };
+pub use alloc::{string::String, vec::Vec};
 pub use alloy_primitives::{address, Address};
 pub use bigdecimal::{BigDecimal, RoundingMode};
+pub use core::{
+    cmp::Ordering,
+    num::NonZeroU64,
+    ops::{Deref, Div},
+    str::FromStr,
+};
 pub use lazy_static::lazy_static;
 pub use num_bigint::{BigInt, BigUint, ToBigInt, ToBigUint};
 pub use num_integer::Integer;
 pub use num_traits::{Num, ToPrimitive, Zero};
 pub use rustc_hash::FxHashMap;
-pub use std::{cmp::Ordering, num::NonZeroU64, ops::Div, str::FromStr, sync::Mutex};
 pub use thiserror::Error;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,7 +17,10 @@ pub use crate::{
     error::Error,
     utils::*,
 };
-pub use alloc::{string::String, vec::Vec};
+pub use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 pub use alloy_primitives::{address, Address};
 pub use bigdecimal::{BigDecimal, RoundingMode};
 pub use core::{


### PR DESCRIPTION
This commit migrates the codebase to use `no_std`, shifting various library imports from `std` to `core` and `alloc`. It also removes `std::sync::Mutex` and a cache intended to store Ether instances. A configuration attribute for disabling `std` in non-test environments has been added in `lib.rs`. All necessary changes to enable compatibility with `no_std` environments have been accounted for.

Closes #69.