### PR TITLE
chore: Bump version to 1.1.0 and update alloy-primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "uniswap-sdk-core"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
 license = "MIT"
 
 [dependencies]
-alloy-primitives = "0.7"
+alloy-primitives = "0.8"
 bigdecimal = "0.4.5"
 eth_checksum = { version = "0.1.2", optional = true }
 lazy_static = "1.5"


### PR DESCRIPTION
Updated the package version to 1.1.0 to reflect new changes. Additionally, upgraded alloy-primitives dependency from version 0.7 to 0.8 to maintain compatibility and leverage new features.