### PR TITLE
refactor!: address mappings for conciseness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -1,8 +1,7 @@
 use crate::prelude::*;
+use alloc::vec;
 
 type AddressMap = FxHashMap<u64, Address>;
-type ChainMap = FxHashMap<u64, ChainAddresses>;
-type ChainAddress = FxHashMap<u64, Address>;
 
 /// Represents the addresses of various core contracts of Uniswap on a network.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -29,14 +28,15 @@ pub const DEFAULT_NETWORKS: [ChainId; 3] = [ChainId::MAINNET, ChainId::GOERLI, C
 ///
 ///
 /// returns: [`AdresssMap`]
-pub fn construct_same_address_map(address: Address, additional_networks: &[ChainId]) -> AddressMap {
+#[inline]
+fn construct_same_address_map(address: Address, additional_networks: &[ChainId]) -> AddressMap {
     let mut networks = DEFAULT_NETWORKS.to_vec();
     networks.extend_from_slice(additional_networks);
-    let mut map = AddressMap::default();
-    for chain_id in networks {
-        map.insert(chain_id as u64, address);
-    }
-    map
+    AddressMap::from_iter(
+        networks
+            .into_iter()
+            .map(|chain_id| (chain_id as u64, address)),
+    )
 }
 
 lazy_static! {
@@ -45,9 +45,9 @@ lazy_static! {
         address!("1f9840a85d5aF5bf1D1762F925BDADdC4201F984"),
         &[
             ChainId::OPTIMISM,
-            ChainId::ARBITRUMONE,
+            ChainId::ARBITRUM_ONE,
             ChainId::POLYGON,
-            ChainId::POLYGONMUMBAI,
+            ChainId::POLYGON_MUMBAI,
             ChainId::SEPOLIA,
         ]
     );
@@ -62,47 +62,47 @@ pub const V2_FACTORY_ADDRESS: Address = address!("5C69bEe701ef814a2B6a3EDD4B1652
 
 lazy_static! {
     /// A map of Uniswap V2 Factory addresses for various networks.
-    pub static ref V2_FACTORY_ADDRESSES: FxHashMap<u64, Address> = {
-        let mut m = FxHashMap::default();
-        m.insert(ChainId::MAINNET as u64, V2_FACTORY_ADDRESS);
-        m.insert(ChainId::GOERLI as u64, V2_FACTORY_ADDRESS);
-        m.insert(
-            ChainId::SEPOLIA as u64,
-            address!("B7f907f7A9eBC822a80BD25E224be42Ce0A698A0"),
-        );
-        m.insert(
-            ChainId::OPTIMISM as u64,
-            address!("0c3c1c532F1e39EdF36BE9Fe0bE1410313E074Bf"),
-        );
-        m.insert(
-            ChainId::ARBITRUMONE as u64,
-            address!("f1D7CC64Fb4452F05c498126312eBE29f30Fbcf9"),
-        );
-        m.insert(
-            ChainId::AVALANCHE as u64,
-            address!("9e5A52f57b3038F1B8EeE45F28b3C1967e22799C"),
-        );
-        m.insert(
-            ChainId::BASE as u64,
-            address!("8909dc15e40173ff4699343b6eb8132c65e18ec6"),
-        );
-        m.insert(
-            ChainId::BNB as u64,
-            address!("8909Dc15e40173Ff4699343b6eB8132c65e18eC6"),
-        );
-        m.insert(
-            ChainId::POLYGON as u64,
-            address!("9e5A52f57b3038F1B8EeE45F28b3C1967e22799C"),
-        );
-        m.insert(
-            ChainId::CELO as u64,
-            address!("79a530c8e2fA8748B7B40dd3629C0520c2cCf03f"),
-        );
-        m.insert(
-            ChainId::BLAST as u64,
-            address!("5C346464d33F90bABaf70dB6388507CC889C1070"),
-        );
-        m
+    pub static ref V2_FACTORY_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(vec![
+            (ChainId::MAINNET as u64, V2_FACTORY_ADDRESS),
+            (ChainId::GOERLI as u64, V2_FACTORY_ADDRESS),
+            (
+                ChainId::SEPOLIA as u64,
+                address!("B7f907f7A9eBC822a80BD25E224be42Ce0A698A0"),
+            ),
+            (
+                ChainId::OPTIMISM as u64,
+                address!("0c3c1c532F1e39EdF36BE9Fe0bE1410313E074Bf"),
+            ),
+            (
+                ChainId::ARBITRUM_ONE as u64,
+                address!("f1D7CC64Fb4452F05c498126312eBE29f30Fbcf9"),
+            ),
+            (
+                ChainId::AVALANCHE as u64,
+                address!("9e5A52f57b3038F1B8EeE45F28b3C1967e22799C"),
+            ),
+            (
+                ChainId::BASE as u64,
+                address!("8909dc15e40173ff4699343b6eb8132c65e18ec6"),
+            ),
+            (
+                ChainId::BNB as u64,
+                address!("8909Dc15e40173Ff4699343b6eB8132c65e18eC6"),
+            ),
+            (
+                ChainId::POLYGON as u64,
+                address!("9e5A52f57b3038F1B8EeE45F28b3C1967e22799C"),
+            ),
+            (
+                ChainId::CELO as u64,
+                address!("79a530c8e2fA8748B7B40dd3629C0520c2cCf03f"),
+            ),
+            (
+                ChainId::BLAST as u64,
+                address!("5C346464d33F90bABaf70dB6388507CC889C1070"),
+            ),
+        ])
     };
 }
 
@@ -115,45 +115,45 @@ lazy_static! {
     /// This map is used to look up the address of the Uniswap V2 Router contract
     /// for a given network. The keys in the map are the network IDs, and the values
     /// are the corresponding contract addresses.
-    pub static ref V2_ROUTER_ADDRESSES: FxHashMap<u64, Address> = {
-        let mut m = FxHashMap::default();
-        m.insert(ChainId::MAINNET as u64, V2_ROUTER_ADDRESS);
-        m.insert(ChainId::GOERLI as u64, V2_ROUTER_ADDRESS);
-        m.insert(
-            ChainId::ARBITRUMONE as u64,
-            address!("4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
-        );
-        m.insert(
-            ChainId::OPTIMISM as u64,
-            address!("4a7b5da61326a6379179b40d00f57e5bbdc962c2"),
-        );
-        m.insert(
-            ChainId::BASE as u64,
-            address!("4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
-        );
-        m.insert(
-            ChainId::AVALANCHE as u64,
-            address!("4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
-        );
-        m.insert(
-            ChainId::BNB as u64,
-            address!("4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
-        );
-        m.insert(
-            ChainId::POLYGON as u64,
-            address!("edf6066a2b290c185783862c7f4776a2c8077ad1"),
-        );
-        m.insert(
-            ChainId::BLAST as u64,
-            address!("BB66Eb1c5e875933D44DAe661dbD80e5D9B03035"),
-        );
-        m
+    pub static ref V2_ROUTER_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(vec![
+            (ChainId::MAINNET as u64, V2_ROUTER_ADDRESS),
+            (ChainId::GOERLI as u64, V2_ROUTER_ADDRESS),
+            (
+                ChainId::ARBITRUM_ONE as u64,
+                address!("4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
+            ),
+            (
+                ChainId::OPTIMISM as u64,
+                address!("4a7b5da61326a6379179b40d00f57e5bbdc962c2"),
+            ),
+            (
+                ChainId::BASE as u64,
+                address!("4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
+            ),
+            (
+                ChainId::AVALANCHE as u64,
+                address!("4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
+            ),
+            (
+                ChainId::BNB as u64,
+                address!("4752ba5dbc23f44d87826276bf6fd6b1c372ad24"),
+            ),
+            (
+                ChainId::POLYGON as u64,
+                address!("edf6066a2b290c185783862c7f4776a2c8077ad1"),
+            ),
+            (
+                ChainId::BLAST as u64,
+                address!("BB66Eb1c5e875933D44DAe661dbD80e5D9B03035"),
+            ),
+        ])
     };
 }
 
-impl Default for ChainAddresses {
+impl ChainAddresses {
     /// Networks that share most of the same addresses i.e. Mainnet, Goerli, Optimism, Arbitrum,
-    fn default() -> Self {
+    const fn default() -> Self {
         Self {
             v3_core_factory_address: address!("1F98431c8aD98523631AE4a59f267346ea31F984"),
             multicall_address: address!("1F98415757620B543A52E61c46B32eB19261F984"),
@@ -169,52 +169,34 @@ impl Default for ChainAddresses {
     }
 }
 
-lazy_static! {
-    /// The `MAINNET_ADDRESSES` struct holds the Uniswap contract addresses for the Ethereum Mainnet.
-    pub static ref MAINNET_ADDRESSES: ChainAddresses = {
-        ChainAddresses {
-            v1_mixed_route_quoter_address: Some(address!(
-                "84E44095eeBfEC7793Cd7d5b57B7e401D7f1cA2E"
-            )),
-            ..Default::default()
-        }
-    };
-}
+/// The `MAINNET_ADDRESSES` struct holds the Uniswap contract addresses for the Ethereum Mainnet.
+const MAINNET_ADDRESSES: ChainAddresses = ChainAddresses {
+    v1_mixed_route_quoter_address: Some(address!("84E44095eeBfEC7793Cd7d5b57B7e401D7f1cA2E")),
+    ..ChainAddresses::default()
+};
 
-lazy_static! {
-    /// The `GOERLI_ADDRESSES` struct holds the Uniswap contract addresses for the Goerli Testnet.
-    pub static ref GOERLI_ADDRESSES: ChainAddresses = {
-        ChainAddresses {
-            v1_mixed_route_quoter_address: Some(address!(
-                "Ba60b6e6fF25488308789E6e0A65D838be34194e"
-            )),
-            ..Default::default()
-        }
-    };
-}
+/// The `GOERLI_ADDRESSES` struct holds the Uniswap contract addresses for the Goerli Testnet.
+const GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
+    v1_mixed_route_quoter_address: Some(address!("Ba60b6e6fF25488308789E6e0A65D838be34194e")),
+    ..ChainAddresses::default()
+};
 
-lazy_static! {
-    /// The `OPTIMISM_ADDRESSES` struct holds the Uniswap contract addresses for the Optimism network.
-    pub static ref OPTIMISM_ADDRESSES: ChainAddresses = ChainAddresses::default();
-}
+/// The `OPTIMISM_ADDRESSES` struct holds the Uniswap contract addresses for the Optimism network.
+const OPTIMISM_ADDRESSES: ChainAddresses = ChainAddresses::default();
 
-lazy_static! {
-    /// The `ARBITRUM_ONE_ADDRESSES` struct holds the Uniswap contract addresses for the Arbitrum One network.
-    pub static ref ARBITUM_ONE_ADDRESSES: ChainAddresses = {
-        ChainAddresses {
-            multicall_address: address!("adF885960B47eA2CD9B55E6DAc6B42b7Cb2806dB"),
-            tick_lens_address: Some(address!("bfd8137f7d1516D3ea5cA83523914859ec47F573")),
-            ..Default::default()
-        }
-    };
-}
-lazy_static! {
-    /// The `POLYGON_ADDRESSES` struct holds the Uniswap contract addresses for the Polygon network.
-    pub static ref POLYGON_ADDRESSES: ChainAddresses = ChainAddresses::default();
-}
+/// The `ARBITRUM_ONE_ADDRESSES` struct holds the Uniswap contract addresses for the Arbitrum One
+/// network.
+const ARBITUM_ONE_ADDRESSES: ChainAddresses = ChainAddresses {
+    multicall_address: address!("adF885960B47eA2CD9B55E6DAc6B42b7Cb2806dB"),
+    tick_lens_address: Some(address!("bfd8137f7d1516D3ea5cA83523914859ec47F573")),
+    ..ChainAddresses::default()
+};
+
+/// The `POLYGON_ADDRESSES` struct holds the Uniswap contract addresses for the Polygon network.
+const POLYGON_ADDRESSES: ChainAddresses = ChainAddresses::default();
 
 /// celo v3 addresses
-pub const CELO_ADDRESSES: ChainAddresses = ChainAddresses {
+const CELO_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("AfE208a311B21f13EF87E33A90049fC17A7acDEc"),
     multicall_address: address!("633987602DE5C4F337e3DbF265303A1080324204"),
     quoter_address: address!("82825d0554fA07f7FC52Ab63c961F330fdEFa8E8"),
@@ -228,7 +210,7 @@ pub const CELO_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// BNB v3 addresses
-pub const BNB_ADDRESSES: ChainAddresses = ChainAddresses {
+const BNB_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("dB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7"),
     multicall_address: address!("963Df249eD09c358A4819E39d9Cd5736c3087184"),
     quoter_address: address!("78D78E420Da98ad378D7799bE8f4AF69033EB077"),
@@ -242,7 +224,7 @@ pub const BNB_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Optimism Goerli addresses
-pub const OPTIMISM_GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
+const OPTIMISM_GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("B656dA17129e7EB733A557f4EBc57B76CFbB5d10"),
     multicall_address: address!("07F2D8a2a02251B62af965f22fC4744A5f96BCCd"),
     quoter_address: address!("9569CbA925c8ca2248772A9A4976A516743A246F"),
@@ -256,7 +238,7 @@ pub const OPTIMISM_GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Optimism Sepolia addresses
-pub const OPTIMISM_SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
+const OPTIMISM_SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("8CE191193D15ea94e11d327b4c7ad8bbE520f6aF"),
     multicall_address: address!("80e4e06841bb76AA9735E0448cB8d003C0EF009a"),
     quoter_address: address!("0FBEa6cf957d95ee9313490050F6A0DA68039404"),
@@ -270,7 +252,7 @@ pub const OPTIMISM_SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Arbitrum Goerli v3 addresses
-pub const ARBITRUM_GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
+const ARBITRUM_GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("4893376342d5D7b3e31d4184c08b265e5aB2A3f6"),
     multicall_address: address!("8260CB40247290317a4c062F3542622367F206Ee"),
     quoter_address: address!("1dd92b83591781D0C6d98d07391eea4b9a6008FA"),
@@ -284,7 +266,7 @@ pub const ARBITRUM_GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Arbitrum sepolia v3 addresses
-pub const ARBITRUM_SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
+const ARBITRUM_SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("248AB79Bbb9bC29bB72f7Cd42F17e054Fc40188e"),
     multicall_address: address!("2B718b475e385eD29F56775a66aAB1F5cC6B2A0A"),
     quoter_address: address!("2779a0CC1c3e0E44D2542EC3e79e3864Ae93Ef0B"),
@@ -298,7 +280,7 @@ pub const ARBITRUM_SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// sepolia v3 addresses
-pub const SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
+const SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("0227628f3F023bb0B980b67D528571c95c6DaC1c"),
     multicall_address: address!("D7F33bCdb21b359c8ee6F0251d30E94832baAd07"),
     quoter_address: address!("Ed1f6473345F45b75F8179591dd5bA1888cf2FB3"),
@@ -312,7 +294,7 @@ pub const SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Avalanche v3 addresses
-pub const AVALANCHE_ADDRESSES: ChainAddresses = ChainAddresses {
+const AVALANCHE_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("740b1c1de25031C31FF4fC9A62f554A55cdC1baD"),
     multicall_address: address!("0139141Cd4Ee88dF3Cdb65881D411bAE271Ef0C2"),
     quoter_address: address!("be0F5544EC67e9B3b2D979aaA43f18Fd87E6257F"),
@@ -326,7 +308,7 @@ pub const AVALANCHE_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Base v3 addresses
-pub const BASE_ADDRESSES: ChainAddresses = ChainAddresses {
+const BASE_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("33128a8fC17869897dcE68Ed026d694621f6FDfD"),
     multicall_address: address!("091e99cb1C49331a94dD62755D168E941AbD0693"),
     quoter_address: address!("3d4e44Eb1374240CE5F1B871ab261CD16335B76a"),
@@ -340,7 +322,7 @@ pub const BASE_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Base Goerli v3 addresses
-pub const BASE_GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
+const BASE_GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("9323c1d6D800ed51Bd7C6B216cfBec678B7d0BC2"),
     multicall_address: address!("B206027a9E0E13F05eBEFa5D2402Bab3eA716439"),
     quoter_address: address!("edf539058e28E5937dAef3f69cEd0b25fbE66Ae9"),
@@ -354,7 +336,7 @@ pub const BASE_GOERLI_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Zora addresses
-pub const ZORA_ADDRESSES: ChainAddresses = ChainAddresses {
+const ZORA_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("7145F8aeef1f6510E92164038E1B6F8cB2c42Cbb"),
     multicall_address: address!("A51c76bEE6746cB487a7e9312E43e2b8f4A37C15"),
     quoter_address: address!("11867e1b3348F3ce4FcC170BC5af3d23E07E64Df"),
@@ -368,7 +350,7 @@ pub const ZORA_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Zora Sepolia addresses
-pub const ZORA_SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
+const ZORA_SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("4324A677D74764f46f33ED447964252441aA8Db6"),
     multicall_address: address!("A1E7e3A69671C4494EC59Dbd442de930a93F911A"),
     quoter_address: address!("C195976fEF0985886E37036E2DF62bF371E12Df0"),
@@ -382,7 +364,7 @@ pub const ZORA_SEPOLIA_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Rootstock addresses
-pub const ROOTSTOCK_ADDRESSES: ChainAddresses = ChainAddresses {
+const ROOTSTOCK_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("aF37EC98A00FD63689CF3060BF3B6784E00caD82"),
     multicall_address: address!("996a9858cDfa45Ad68E47c9A30a7201E29c6a386"),
     quoter_address: address!("b51727c996C68E60F598A923a5006853cd2fEB31"),
@@ -396,7 +378,7 @@ pub const ROOTSTOCK_ADDRESSES: ChainAddresses = ChainAddresses {
 };
 
 /// Blast addresses
-pub const BLAST_ADDRESSES: ChainAddresses = ChainAddresses {
+const BLAST_ADDRESSES: ChainAddresses = ChainAddresses {
     v3_core_factory_address: address!("792edAdE80af5fC680d96a2eD80A44247D2Cf6Fd"),
     multicall_address: address!("dC7f370de7631cE9e2c2e1DCDA6B3B5744Cf4705"),
     quoter_address: address!("6Cdcd65e03c1CEc3730AeeCd45bc140D57A25C77"),
@@ -415,116 +397,85 @@ lazy_static! {
     /// This map is used to look up the addresses of various Uniswap contracts
     /// for a given network. The keys in the map are the network IDs, and the values
     /// are the corresponding contract addresses.
-    pub static ref CHAIN_TO_ADDRESSES_MAP: ChainMap = {
-        let mut new_map = ChainMap::default();
-        new_map.insert(ChainId::BNB as u64, BNB_ADDRESSES);
-
-        new_map.insert(ChainId::AVALANCHE as u64, AVALANCHE_ADDRESSES);
-        new_map.insert(ChainId::MAINNET as u64, *MAINNET_ADDRESSES);
-        new_map.insert(ChainId::SEPOLIA as u64, SEPOLIA_ADDRESSES);
-        new_map.insert(ChainId::GOERLI as u64, *GOERLI_ADDRESSES);
-        new_map.insert(ChainId::ARBITRUMONE as u64, *ARBITUM_ONE_ADDRESSES);
-        new_map.insert(ChainId::ARBITRUMGOERLI as u64, ARBITRUM_GOERLI_ADDRESSES);
-        new_map.insert(ChainId::ARBITRUMSEPOLIA as u64, ARBITRUM_SEPOLIA_ADDRESSES);
-        new_map.insert(ChainId::CELO as u64, CELO_ADDRESSES);
-        new_map.insert(ChainId::CELOALFAJORES as u64, CELO_ADDRESSES);
-
-        new_map.insert(ChainId::POLYGON as u64, *POLYGON_ADDRESSES);
-        new_map.insert(ChainId::POLYGONMUMBAI as u64, *POLYGON_ADDRESSES);
-        new_map.insert(ChainId::OPTIMISM as u64, *OPTIMISM_ADDRESSES);
-        new_map.insert(ChainId::OPTIMISMGOERLI as u64, OPTIMISM_GOERLI_ADDRESSES);
-        new_map.insert(ChainId::OPTIMISMSEPOLIA as u64, OPTIMISM_SEPOLIA_ADDRESSES);
-        new_map.insert(ChainId::BASEGOERLI as u64, BASE_GOERLI_ADDRESSES);
-        new_map.insert(ChainId::BASE as u64, BASE_ADDRESSES);
-        new_map.insert(ChainId::ZORA as u64, ZORA_ADDRESSES);
-        new_map.insert(ChainId::ZORASEPOLIA as u64, ZORA_SEPOLIA_ADDRESSES);
-        new_map.insert(ChainId::ROOTSTOCK as u64, ROOTSTOCK_ADDRESSES);
-        new_map.insert(ChainId::BLAST as u64, BLAST_ADDRESSES);
-        new_map
+    pub static ref CHAIN_TO_ADDRESSES_MAP: FxHashMap<u64, ChainAddresses> = {
+        FxHashMap::from_iter(vec![
+            (ChainId::MAINNET as u64, MAINNET_ADDRESSES),
+            (ChainId::OPTIMISM as u64, OPTIMISM_ADDRESSES),
+            (ChainId::ARBITRUM_ONE as u64, ARBITUM_ONE_ADDRESSES),
+            (ChainId::POLYGON as u64, POLYGON_ADDRESSES),
+            (ChainId::POLYGON_MUMBAI as u64, POLYGON_ADDRESSES),
+            (ChainId::GOERLI as u64, GOERLI_ADDRESSES),
+            (ChainId::CELO as u64, CELO_ADDRESSES),
+            (ChainId::CELO_ALFAJORES as u64, CELO_ADDRESSES),
+            (ChainId::BNB as u64, BNB_ADDRESSES),
+            (ChainId::OPTIMISM_GOERLI as u64, OPTIMISM_GOERLI_ADDRESSES),
+            (ChainId::OPTIMISM_SEPOLIA as u64, OPTIMISM_SEPOLIA_ADDRESSES),
+            (ChainId::ARBITRUM_GOERLI as u64, ARBITRUM_GOERLI_ADDRESSES),
+            (ChainId::ARBITRUM_SEPOLIA as u64, ARBITRUM_SEPOLIA_ADDRESSES),
+            (ChainId::SEPOLIA as u64, SEPOLIA_ADDRESSES),
+            (ChainId::AVALANCHE as u64, AVALANCHE_ADDRESSES),
+            (ChainId::BASE as u64, BASE_ADDRESSES),
+            (ChainId::BASE_GOERLI as u64, BASE_GOERLI_ADDRESSES),
+            (ChainId::ZORA as u64, ZORA_ADDRESSES),
+            (ChainId::ZORA_SEPOLIA as u64, ZORA_SEPOLIA_ADDRESSES),
+            (ChainId::ROOTSTOCK as u64, ROOTSTOCK_ADDRESSES),
+            (ChainId::BLAST as u64, BLAST_ADDRESSES),
+        ])
     };
 }
 
 lazy_static! {
     /// V3 Contract Addresses
-    pub static ref V3_CORE_FACTORY_ADDRESSES: ChainAddress = {
-        let mut chain_add = ChainAddress::default();
-        for chain_id in SUPPORTED_CHAINS {
-            chain_add.insert(
-                chain_id as u64,
-                CHAIN_TO_ADDRESSES_MAP
-                    .get(&(chain_id as u64))
-                    .unwrap()
-                    .v3_core_factory_address,
-            );
-        }
-        chain_add
+    pub static ref V3_CORE_FACTORY_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(SUPPORTED_CHAINS.map(|chain_id| {
+            (chain_id as u64, CHAIN_TO_ADDRESSES_MAP[&(chain_id as u64)].v3_core_factory_address)
+        }))
     };
 }
 
 lazy_static! {
     /// V3 Contract Addresses
-    pub static ref V3_MIGRATOR_ADDRESSES: ChainAddress = {
-        let mut chain_add = ChainAddress::default();
-        for chain_id in SUPPORTED_CHAINS {
-            chain_add.insert(
-                chain_id as u64,
-                CHAIN_TO_ADDRESSES_MAP
-                    .get(&(chain_id as u64))
-                    .unwrap()
-                    .v3_migrator_address
-                    .unwrap(),
-            );
-        }
-        chain_add
+    pub static ref V3_MIGRATOR_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(SUPPORTED_CHAINS.into_iter().filter_map(|chain_id| {
+            CHAIN_TO_ADDRESSES_MAP[&(chain_id as u64)]
+                .v3_migrator_address
+                .map(|address| (chain_id as u64, address))
+        }))
     };
 }
 
 lazy_static! {
     /// V3 Contract Addresses
-    pub static ref MULTICALL_ADDRESSES: ChainAddress = {
-        let mut chain_add = ChainAddress::default();
-        for chain_id in SUPPORTED_CHAINS {
-            chain_add.insert(
-                chain_id as u64,
-                CHAIN_TO_ADDRESSES_MAP
-                    .get(&(chain_id as u64))
-                    .unwrap()
-                    .multicall_address,
-            );
-        }
-        chain_add
+    pub static ref MULTICALL_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(SUPPORTED_CHAINS.map(|chain_id| {
+            (chain_id as u64, CHAIN_TO_ADDRESSES_MAP[&(chain_id as u64)].multicall_address)
+        }))
     };
 }
 
 lazy_static! {
-/// The oldest V0 governance address
-pub static ref GOVERNANCE_ALPHA_V0_ADDRESSES: AddressMap = {
-    construct_same_address_map(address!("5e4be8Bc9637f0EAA1A755019e06A68ce081D58F"), &[])
-};
+    /// The oldest V0 governance address
+    pub static ref GOVERNANCE_ALPHA_V0_ADDRESSES: AddressMap = {
+        construct_same_address_map(address!("5e4be8Bc9637f0EAA1A755019e06A68ce081D58F"), &[])
+    };
 }
 
 lazy_static! {
-/// The older V1 governance address
-pub static ref GOVERNANCE_ALPHA_V1_ADDRESSES: AddressMap = {
-    let mut new_map = AddressMap::default();
-    new_map.insert(
-        ChainId::MAINNET as u64,
-        address!("C4e172459f1E7939D522503B81AFAaC1014CE6F6"),
-    );
-    new_map
-};
+    /// The older V1 governance address
+    pub static ref GOVERNANCE_ALPHA_V1_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(vec![
+            (ChainId::MAINNET as u64, address!("C4e172459f1E7939D522503B81AFAaC1014CE6F6")),
+        ])
+    };
 }
 
 lazy_static! {
-/// The latest governor bravo that is currently admin of timelock
-pub static ref GOVERNANCE_BRAVO_ADDRESSES: AddressMap = {
-    let mut new_map = AddressMap::default();
-    new_map.insert(
-        ChainId::MAINNET as u64,
-        address!("408ED6354d4973f66138C91495F2f2FCbd8724C3"),
-    );
-    new_map
-};
+    /// The latest governor bravo that is currently admin of timelock
+    pub static ref GOVERNANCE_BRAVO_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(vec![
+            (ChainId::MAINNET as u64, address!("408ED6354d4973f66138C91495F2f2FCbd8724C3")),
+        ])
+    };
 }
 
 lazy_static! {
@@ -536,24 +487,18 @@ lazy_static! {
 lazy_static! {
     /// The `MERKLE_DISTRIBUTOR_ADDRESS` struct holds the merkle distributor contract address for the mainnet.
     pub static ref MERKLE_DISTRIBUTOR_ADDRESS: AddressMap = {
-        let mut new_map = AddressMap::default();
-        new_map.insert(
-            ChainId::MAINNET as u64,
-            address!("090D4613473dEE047c3f2706764f49E0821D256e"),
-        );
-        new_map
+        AddressMap::from_iter(vec![
+            (ChainId::MAINNET as u64, address!("090D4613473dEE047c3f2706764f49E0821D256e")),
+        ])
     };
 }
 
 lazy_static! {
     /// The `ARGENT_WALLET_DETECTOR_ADDRESS` struct holds the Argent Wallet Detector contract address for the mainnet.
     pub static ref ARGENT_WALLET_DETECTOR_ADDRESS: AddressMap = {
-        let mut new_map = AddressMap::default();
-        new_map.insert(
-            ChainId::MAINNET as u64,
-            address!("eca4B0bDBf7c55E9b7925919d03CbF8Dc82537E8"),
-        );
-        new_map
+        AddressMap::from_iter(vec![
+            (ChainId::MAINNET as u64, address!("eca4B0bDBf7c55E9b7925919d03CbF8Dc82537E8")),
+        ])
     };
 }
 
@@ -562,18 +507,10 @@ lazy_static! {
     ///
     /// This includes the addresses for the quoter contract on different networks.
     /// Each field in the struct corresponds to a specific contract and its address on the network
-    pub static ref QUOTER_ADDRESSES: ChainAddress = {
-        let mut chain_add = ChainAddress::default();
-        for chain_id in SUPPORTED_CHAINS {
-            chain_add.insert(
-                chain_id as u64,
-                CHAIN_TO_ADDRESSES_MAP
-                    .get(&(chain_id as u64))
-                    .unwrap()
-                    .quoter_address,
-            );
-        }
-        chain_add
+    pub static ref QUOTER_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(SUPPORTED_CHAINS.map(|chain_id| {
+            (chain_id as u64, CHAIN_TO_ADDRESSES_MAP[&(chain_id as u64)].quoter_address)
+        }))
     };
 }
 
@@ -582,26 +519,12 @@ lazy_static! {
     ///
     /// This includes the addresses for the non-fungible position manager contract on different networks.
     /// Each field in the struct corresponds to a specific contract and its address on the network.
-    pub static ref NONFUNGIBLE_POSITION_MANAGER_ADDRESSES: ChainAddress = {
-        let mut chain_add = ChainAddress::default();
-        for chain_id in SUPPORTED_CHAINS {
-            if CHAIN_TO_ADDRESSES_MAP
-                .get(&(chain_id as u64))
-                .unwrap()
+    pub static ref NONFUNGIBLE_POSITION_MANAGER_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(SUPPORTED_CHAINS.into_iter().filter_map(|chain_id| {
+            CHAIN_TO_ADDRESSES_MAP[&(chain_id as u64)]
                 .nonfungible_position_manager_address
-                .is_some()
-            {
-                chain_add.insert(
-                    chain_id as u64,
-                    CHAIN_TO_ADDRESSES_MAP
-                        .get(&(chain_id as u64))
-                        .unwrap()
-                        .nonfungible_position_manager_address
-                        .unwrap(),
-                );
-            }
-        }
-        chain_add
+                .map(|address| (chain_id as u64, address))
+        }))
     };
 }
 
@@ -620,12 +543,9 @@ lazy_static! {
     /// This includes the addresses for the SOCKS Controller contract on different networks.
     /// Each field in the struct corresponds to a specific contract and its address on the network.
     pub static ref SOCKS_CONTROLLER_ADDRESSES: AddressMap = {
-        let mut new_map = AddressMap::default();
-        new_map.insert(
-            ChainId::MAINNET as u64,
-            address!("65770b5283117639760beA3F867b69b3697a91dd"),
-        );
-        new_map
+        AddressMap::from_iter(vec![
+            (ChainId::MAINNET as u64, address!("65770b5283117639760beA3F867b69b3697a91dd")),
+        ])
     };
 }
 
@@ -634,26 +554,12 @@ lazy_static! {
     ///
     /// This includes the addresses for the tick lens contract on different networks.
     /// Each field in the struct corresponds to a specific contract and its address on the network.
-    pub static ref TICK_LENS_ADDRESSES: ChainAddress = {
-        let mut chain_add = ChainAddress::default();
-        for chain_id in SUPPORTED_CHAINS {
-            if CHAIN_TO_ADDRESSES_MAP
-                .get(&(chain_id as u64))
-                .unwrap()
+    pub static ref TICK_LENS_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(SUPPORTED_CHAINS.into_iter().filter_map(|chain_id| {
+            CHAIN_TO_ADDRESSES_MAP[&(chain_id as u64)]
                 .tick_lens_address
-                .is_some()
-            {
-                chain_add.insert(
-                    chain_id as u64,
-                    CHAIN_TO_ADDRESSES_MAP
-                        .get(&(chain_id as u64))
-                        .unwrap()
-                        .tick_lens_address
-                        .unwrap(),
-                );
-            }
-        }
-        chain_add
+                .map(|address| (chain_id as u64, address))
+        }))
     };
 }
 
@@ -662,57 +568,28 @@ lazy_static! {
     ///
     /// This includes the addresses for the mixed route quoter contract on different networks.
     /// Each field in the struct corresponds to a specific contract and its address on the network.
-    pub static ref MIXED_ROUTE_QUOTER_V1_ADDRESSES: ChainAddress = {
-        let mut chain_add = ChainAddress::default();
-        for chain_id in SUPPORTED_CHAINS {
-            if CHAIN_TO_ADDRESSES_MAP
-                .get(&(chain_id as u64))
-                .unwrap()
+    pub static ref MIXED_ROUTE_QUOTER_V1_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(SUPPORTED_CHAINS.into_iter().filter_map(|chain_id| {
+            CHAIN_TO_ADDRESSES_MAP[&(chain_id as u64)]
                 .v1_mixed_route_quoter_address
-                .is_some()
-            {
-                chain_add.insert(
-                    chain_id as u64,
-                    CHAIN_TO_ADDRESSES_MAP
-                        .get(&(chain_id as u64))
-                        .unwrap()
-                        .v1_mixed_route_quoter_address
-                        .unwrap(),
-                );
-            }
-        }
-        chain_add
+                .map(|address| (chain_id as u64, address))
+        }))
     };
 }
 
-/// Returns the address of the Uniswap V2 Router contract for the specified chain.
-///
-/// If the chain ID is not found in the `CHAIN_TO_ADDRESSES_MAP`, it defaults to the
-/// address of the router contract on the Ethereum mainnet.
-///
-/// # Arguments
-///
-/// * `chain_id` - The ID of the chain for which to retrieve the router address.
-///
-/// # Returns
-///
-/// * `Address` - The address of the Uniswap V2 Router contract for the specified chain.
-pub fn swap_router02_address(chain_id: u64) -> Address {
-    if CHAIN_TO_ADDRESSES_MAP.contains_key(&chain_id)
-        && CHAIN_TO_ADDRESSES_MAP
-            .get(&chain_id)
-            .unwrap()
-            .swap_router02_address
-            .is_some()
-    {
-        CHAIN_TO_ADDRESSES_MAP
-            .get(&chain_id)
-            .unwrap()
-            .swap_router02_address
-            .unwrap()
-    } else {
-        address!("68b3465833fb72A70ecDF485E0e4C7bD8665Fc45")
-    }
+lazy_static! {
+    pub static ref SWAP_ROUTER_02_ADDRESSES: AddressMap = {
+        AddressMap::from_iter(SUPPORTED_CHAINS.map(|chain_id| {
+            let swap_router02_address = if let Some(address) =
+                CHAIN_TO_ADDRESSES_MAP[&(chain_id as u64)].swap_router02_address
+            {
+                address
+            } else {
+                address!("68b3465833fb72A70ecDF485E0e4C7bD8665Fc45")
+            };
+            (chain_id as u64, swap_router02_address)
+        }))
+    };
 }
 
 #[cfg(test)]
@@ -721,7 +598,7 @@ mod tests {
 
     #[test]
     fn test_swap_router_02_addresses_base() {
-        let address = swap_router02_address(ChainId::BASE as u64);
+        let address = SWAP_ROUTER_02_ADDRESSES[&(ChainId::BASE as u64)];
         assert_eq!(
             address,
             address!("2626664c2603336E57B271c5C0b26F421741e481")
@@ -730,7 +607,7 @@ mod tests {
 
     #[test]
     fn test_swap_router_02_addresses_base_goerli() {
-        let address = swap_router02_address(ChainId::BASEGOERLI as u64);
+        let address = SWAP_ROUTER_02_ADDRESSES[&(ChainId::BASE_GOERLI as u64)];
         assert_eq!(
             address,
             address!("8357227D4eDc78991Db6FDB9bD6ADE250536dE1d")
@@ -739,7 +616,7 @@ mod tests {
 
     #[test]
     fn test_swap_router_02_addresses_avalanche() {
-        let address = swap_router02_address(ChainId::AVALANCHE as u64);
+        let address = SWAP_ROUTER_02_ADDRESSES[&(ChainId::AVALANCHE as u64)];
         assert_eq!(
             address,
             address!("bb00FF08d01D300023C629E8fFfFcb65A5a578cE")
@@ -748,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_swap_router_02_addresses_bnb() {
-        let address = swap_router02_address(ChainId::BNB as u64);
+        let address = SWAP_ROUTER_02_ADDRESSES[&(ChainId::BNB as u64)];
         assert_eq!(
             address,
             address!("B971eF87ede563556b2ED4b1C0b0019111Dd85d2")
@@ -757,7 +634,7 @@ mod tests {
 
     #[test]
     fn test_swap_router_02_addresses_arbritum_goerli() {
-        let address = swap_router02_address(ChainId::ARBITRUMGOERLI as u64);
+        let address = SWAP_ROUTER_02_ADDRESSES[&(ChainId::ARBITRUM_GOERLI as u64)];
         assert_eq!(
             address,
             address!("68b3465833fb72A70ecDF485E0e4C7bD8665Fc45")
@@ -766,7 +643,7 @@ mod tests {
 
     #[test]
     fn test_swap_router_02_addresses_optimism_sepolia() {
-        let address = swap_router02_address(ChainId::OPTIMISMSEPOLIA as u64);
+        let address = SWAP_ROUTER_02_ADDRESSES[&(ChainId::OPTIMISM_SEPOLIA as u64)];
         assert_eq!(
             address,
             address!("94cC0AaC535CCDB3C01d6787D6413C739ae12bc4")
@@ -775,7 +652,7 @@ mod tests {
 
     #[test]
     fn test_swap_router_02_addresses_sepolia() {
-        let address = swap_router02_address(ChainId::SEPOLIA as u64);
+        let address = SWAP_ROUTER_02_ADDRESSES[&(ChainId::SEPOLIA as u64)];
         assert_eq!(
             address,
             address!("3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E")
@@ -784,7 +661,7 @@ mod tests {
 
     #[test]
     fn test_swap_router_02_addresses_blast() {
-        let address = swap_router02_address(ChainId::BLAST as u64);
+        let address = SWAP_ROUTER_02_ADDRESSES[&(ChainId::BLAST as u64)];
         assert_eq!(
             address,
             address!("549FEB8c9bd4c12Ad2AB27022dA12492aC452B66")

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -1,3 +1,5 @@
+#![allow(non_camel_case_types)]
+
 /// Represents the unique identifier for different blockchain networks supported by the Uniswap SDK.
 ///
 /// Each variant corresponds to a specific blockchain network, identified by its unique chain ID.
@@ -12,23 +14,23 @@ pub enum ChainId {
     /// The Optimism network.
     OPTIMISM = 10,
     /// The Optimism Goerli Testnet.
-    OPTIMISMGOERLI = 420,
+    OPTIMISM_GOERLI = 420,
     /// The Optimism Sepolia Testnet.
-    OPTIMISMSEPOLIA = 11155420,
+    OPTIMISM_SEPOLIA = 11155420,
     /// The Arbitrum One network.
-    ARBITRUMONE = 42161,
+    ARBITRUM_ONE = 42161,
     /// The Arbitrum Goerli Testnet.
-    ARBITRUMGOERLI = 421613,
+    ARBITRUM_GOERLI = 421613,
     /// The Arbitrum Sepolia Testnet.
-    ARBITRUMSEPOLIA = 421614,
+    ARBITRUM_SEPOLIA = 421614,
     /// The Polygon network.
     POLYGON = 137,
     /// The Polygon Mumbai Testnet.
-    POLYGONMUMBAI = 80001,
+    POLYGON_MUMBAI = 80001,
     /// The Celo network.
     CELO = 42220,
     /// The Celo Alfajores Testnet.
-    CELOALFAJORES = 44787,
+    CELO_ALFAJORES = 44787,
     /// The Gnosis network.
     GNOSIS = 100,
     /// The Moonbeam network.
@@ -38,13 +40,13 @@ pub enum ChainId {
     /// The Avalanche network.
     AVALANCHE = 43114,
     /// The Base network.
-    BASEGOERLI = 84531,
+    BASE_GOERLI = 84531,
     /// The Base Goerli Testnet.
     BASE = 8453,
     /// The Zora network.
     ZORA = 7777777,
     /// The Zora Sepolia Testnet.
-    ZORASEPOLIA = 999999999,
+    ZORA_SEPOLIA = 999999999,
     /// The Rootstock network.
     ROOTSTOCK = 30,
     /// The Blast network.
@@ -58,23 +60,23 @@ pub enum ChainId {
 pub const SUPPORTED_CHAINS: [ChainId; 21] = [
     ChainId::MAINNET,
     ChainId::OPTIMISM,
-    ChainId::OPTIMISMGOERLI,
-    ChainId::OPTIMISMSEPOLIA,
-    ChainId::ARBITRUMONE,
-    ChainId::ARBITRUMGOERLI,
-    ChainId::ARBITRUMSEPOLIA,
+    ChainId::OPTIMISM_GOERLI,
+    ChainId::OPTIMISM_SEPOLIA,
+    ChainId::ARBITRUM_ONE,
+    ChainId::ARBITRUM_GOERLI,
+    ChainId::ARBITRUM_SEPOLIA,
     ChainId::POLYGON,
-    ChainId::POLYGONMUMBAI,
+    ChainId::POLYGON_MUMBAI,
     ChainId::GOERLI,
     ChainId::SEPOLIA,
-    ChainId::CELOALFAJORES,
+    ChainId::CELO_ALFAJORES,
     ChainId::CELO,
     ChainId::BNB,
     ChainId::AVALANCHE,
     ChainId::BASE,
-    ChainId::BASEGOERLI,
+    ChainId::BASE_GOERLI,
     ChainId::ZORA,
-    ChainId::ZORASEPOLIA,
+    ChainId::ZORA_SEPOLIA,
     ChainId::ROOTSTOCK,
     ChainId::BLAST,
 ];

--- a/src/entities/ether.rs
+++ b/src/entities/ether.rs
@@ -32,6 +32,7 @@ impl Currency for Ether {
 impl Ether {
     /// Creates a new instance of [`Ether`] with the specified chain ID.
     #[inline]
+    #[must_use]
     pub fn new(chain_id: u64) -> Self {
         Self {
             chain_id,
@@ -44,6 +45,7 @@ impl Ether {
 
     /// Retrieves or creates an [`Ether`] instance for the specified chain ID.
     #[inline]
+    #[must_use]
     pub fn on_chain(chain_id: u64) -> Self {
         Self::new(chain_id)
     }

--- a/src/entities/fractions/currency_amount.rs
+++ b/src/entities/fractions/currency_amount.rs
@@ -33,7 +33,7 @@ impl<T: Currency> CurrencyAmount<T> {
             denominator,
             CurrencyMeta {
                 currency,
-                decimal_scale: BigUint::from(10u64).pow(exponent as u32),
+                decimal_scale: BigUint::from(10_u64).pow(exponent as u32),
             },
         ))
     }

--- a/src/entities/fractions/fraction.rs
+++ b/src/entities/fractions/fraction.rs
@@ -167,9 +167,7 @@ impl<M: Clone> FractionBase<M> for FractionLike<M> {
     fn new(numerator: impl Into<BigInt>, denominator: impl Into<BigInt>, meta: M) -> Self {
         let denominator = denominator.into();
         // Ensure the denominator is not zero
-        if denominator.is_zero() {
-            panic!("denominator is zero");
-        }
+        assert!(!denominator.is_zero(), "denominator is zero");
         Self {
             numerator: numerator.into(),
             denominator,

--- a/src/entities/fractions/percent.rs
+++ b/src/entities/fractions/percent.rs
@@ -35,6 +35,7 @@ impl Percent {
     /// Converts the [`Percent`] to a string with a fixed number of decimal places and rounding
     /// strategy
     #[inline]
+    #[must_use]
     pub fn to_fixed(&self, decimal_places: u8, rounding: Rounding) -> String {
         // Convert the Percent to a simple Fraction, multiply by 100, and then call to_fixed on the
         // result

--- a/src/entities/fractions/price.rs
+++ b/src/entities/fractions/price.rs
@@ -71,8 +71,8 @@ where
         Price::new(
             self.quote_currency.clone(),
             self.base_currency.clone(),
-            self.numerator().clone(),
-            self.denominator().clone(),
+            self.numerator.clone(),
+            self.denominator.clone(),
         )
     }
 
@@ -116,7 +116,7 @@ where
     /// Get the value scaled by decimals for formatting
     #[inline]
     pub fn adjusted_for_decimals(&self) -> Fraction {
-        self.as_fraction() * self.scalar.clone()
+        self.as_fraction() * &self.scalar
     }
 
     /// Converts the adjusted price to a string with a specified number of significant digits and

--- a/src/entities/native_currency.rs
+++ b/src/entities/native_currency.rs
@@ -2,10 +2,12 @@ use crate::prelude::*;
 
 /// Represents the native currency of the chain on which it resides
 pub trait NativeCurrency: Currency {
+    #[inline]
     fn is_native(&self) -> bool {
         true
     }
 
+    #[inline]
     fn is_token(&self) -> bool {
         false
     }

--- a/src/entities/token.rs
+++ b/src/entities/token.rs
@@ -60,6 +60,7 @@ impl Token {
     ///
     /// Panics if `chain_id` is 0.
     #[inline]
+    #[must_use]
     pub const fn new(
         chain_id: u64,
         address: Address,

--- a/src/entities/token.rs
+++ b/src/entities/token.rs
@@ -69,9 +69,7 @@ impl Token {
         buy_fee_bps: Option<BigUint>,
         sell_fee_bps: Option<BigUint>,
     ) -> Self {
-        if chain_id == 0 {
-            panic!("chain id can't be zero");
-        }
+        assert!(chain_id != 0, "chain id can't be zero");
         Self {
             chain_id,
             decimals,

--- a/src/entities/weth9.rs
+++ b/src/entities/weth9.rs
@@ -12,6 +12,7 @@ pub struct WETH9 {
 /// Default implementation for [`WETH9`], creating an instance with predefined WETH tokens on
 /// various chains.
 impl Default for WETH9 {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/src/entities/weth9.rs
+++ b/src/entities/weth9.rs
@@ -29,6 +29,7 @@ impl WETH9 {
     ///
     /// A new `WETH9` instance with predefined WETH tokens.
     #[inline]
+    #[must_use]
     pub fn new() -> Self {
         let tokens = FxHashMap::from_iter(vec![
             (1, Self::on_chain(1).unwrap()),
@@ -56,6 +57,7 @@ impl WETH9 {
     ///
     /// Returns: `Some(Token)` if the token exists, `None` otherwise.
     #[inline]
+    #[must_use]
     pub fn on_chain(chain_id: u64) -> Option<Token> {
         match chain_id {
             1 => Some(token!(
@@ -161,6 +163,7 @@ impl WETH9 {
     ///
     /// Returns: `Some(Token)` if the token exists, `None` otherwise.
     #[inline]
+    #[must_use]
     pub fn get(&self, chain_id: u64) -> Option<&Token> {
         self.tokens.get(&chain_id)
     }

--- a/src/entities/weth9.rs
+++ b/src/entities/weth9.rs
@@ -1,4 +1,5 @@
 use crate::{prelude::*, token};
+use alloc::vec;
 
 /// Represents the WETH9 contract and provides information about WETH tokens on different Ethereum
 /// chains.
@@ -28,20 +29,21 @@ impl WETH9 {
     /// A new `WETH9` instance with predefined WETH tokens.
     #[inline]
     pub fn new() -> Self {
-        let mut tokens = FxHashMap::default();
-        tokens.insert(1, Self::on_chain(1).unwrap());
-        tokens.insert(3, Self::on_chain(3).unwrap());
-        tokens.insert(4, Self::on_chain(4).unwrap());
-        tokens.insert(5, Self::on_chain(5).unwrap());
-        tokens.insert(42, Self::on_chain(42).unwrap());
-        tokens.insert(10, Self::on_chain(10).unwrap());
-        tokens.insert(69, Self::on_chain(69).unwrap());
-        tokens.insert(42161, Self::on_chain(42161).unwrap());
-        tokens.insert(421611, Self::on_chain(421611).unwrap());
-        tokens.insert(8453, Self::on_chain(8453).unwrap());
-        tokens.insert(56, Self::on_chain(56).unwrap());
-        tokens.insert(137, Self::on_chain(137).unwrap());
-        tokens.insert(43114, Self::on_chain(43114).unwrap());
+        let tokens = FxHashMap::from_iter(vec![
+            (1, Self::on_chain(1).unwrap()),
+            (3, Self::on_chain(3).unwrap()),
+            (4, Self::on_chain(4).unwrap()),
+            (5, Self::on_chain(5).unwrap()),
+            (42, Self::on_chain(42).unwrap()),
+            (10, Self::on_chain(10).unwrap()),
+            (69, Self::on_chain(69).unwrap()),
+            (42161, Self::on_chain(42161).unwrap()),
+            (421611, Self::on_chain(421611).unwrap()),
+            (8453, Self::on_chain(8453).unwrap()),
+            (56, Self::on_chain(56).unwrap()),
+            (137, Self::on_chain(137).unwrap()),
+            (43114, Self::on_chain(43114).unwrap()),
+        ]);
         Self { tokens }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,23 @@
     missing_debug_implementations,
     unreachable_pub,
     clippy::missing_const_for_fn,
+    clippy::missing_inline_in_public_items,
+    // clippy::needless_pass_by_value,
     clippy::redundant_clone,
+    // clippy::explicit_iter_loop,
+    // clippy::manual_assert,
+    // clippy::must_use_candidate,
+    // clippy::semicolon_if_nothing_returned,
+    // clippy::suspicious_operation_groupings,
+    // clippy::unseparated_literal_suffix,
+    // clippy::unused_self,
+    // clippy::use_debug,
     rustdoc::all
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 extern crate alloc;
 
 /// Contains functionality related to All Contracts deployed and supported by the Uniswap SDK.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap
 //! decentralized exchange.
+
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![warn(
     missing_copy_implementations,
@@ -12,7 +13,7 @@
     clippy::needless_pass_by_value,
     clippy::redundant_clone,
     clippy::manual_assert,
-    // clippy::must_use_candidate,
+    clippy::must_use_candidate,
     clippy::unseparated_literal_suffix,
     rustdoc::all
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,16 +9,11 @@
     unreachable_pub,
     clippy::missing_const_for_fn,
     clippy::missing_inline_in_public_items,
-    // clippy::needless_pass_by_value,
+    clippy::needless_pass_by_value,
     clippy::redundant_clone,
-    // clippy::explicit_iter_loop,
-    // clippy::manual_assert,
+    clippy::manual_assert,
     // clippy::must_use_candidate,
-    // clippy::semicolon_if_nothing_returned,
-    // clippy::suspicious_operation_groupings,
-    // clippy::unseparated_literal_suffix,
-    // clippy::unused_self,
-    // clippy::use_debug,
+    clippy::unseparated_literal_suffix,
     rustdoc::all
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]

--- a/src/utils/compute_price_impact.rs
+++ b/src/utils/compute_price_impact.rs
@@ -11,7 +11,7 @@ use crate::prelude::*;
 /// returns: Percent
 #[inline]
 pub fn compute_price_impact<TBase: Currency, TQuote: Currency>(
-    mid_price: Price<TBase, TQuote>,
+    mid_price: &Price<TBase, TQuote>,
     input_amount: &CurrencyAmount<TBase>,
     output_amount: &CurrencyAmount<TQuote>,
 ) -> Result<Percent, Error> {
@@ -42,7 +42,7 @@ mod tests {
         //is correct for zero
         assert!(
             compute_price_impact(
-                Price::new(Ether::on_chain(1), token.clone(), 10, 100),
+                &Price::new(Ether::on_chain(1), token.clone(), 10, 100),
                 &CurrencyAmount::from_raw_amount(Ether::on_chain(1), 10).unwrap(),
                 &CurrencyAmount::from_raw_amount(token.clone(), 100).unwrap()
             )
@@ -53,7 +53,7 @@ mod tests {
         //is correct for half output
         assert!(
             compute_price_impact(
-                Price::new(token.clone(), token_1.clone(), 10, 100),
+                &Price::new(token.clone(), token_1.clone(), 10, 100),
                 &CurrencyAmount::from_raw_amount(token.clone(), 10).unwrap(),
                 &CurrencyAmount::from_raw_amount(token_1.clone(), 50).unwrap()
             )
@@ -64,7 +64,7 @@ mod tests {
         //is negative for more output
         assert_eq!(
             compute_price_impact(
-                Price::new(token.clone(), token_1.clone(), 10, 100),
+                &Price::new(token.clone(), token_1.clone(), 10, 100),
                 &CurrencyAmount::from_raw_amount(token.clone(), 10).unwrap(),
                 &CurrencyAmount::from_raw_amount(token_1.clone(), 200).unwrap()
             )

--- a/src/utils/compute_price_impact.rs
+++ b/src/utils/compute_price_impact.rs
@@ -65,8 +65,8 @@ mod tests {
         assert_eq!(
             compute_price_impact(
                 &Price::new(token.clone(), token_1.clone(), 10, 100),
-                &CurrencyAmount::from_raw_amount(token.clone(), 10).unwrap(),
-                &CurrencyAmount::from_raw_amount(token_1.clone(), 200).unwrap()
+                &CurrencyAmount::from_raw_amount(token, 10).unwrap(),
+                &CurrencyAmount::from_raw_amount(token_1, 200).unwrap()
             )
             .unwrap(),
             Percent::new(-10000, 10000)

--- a/src/utils/sorted_insert.rs
+++ b/src/utils/sorted_insert.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 
 /// Given an array of items sorted by `comparator`, insert an item into its sort index and constrain
 /// the size to `maxSize` by removing the last item
+#[inline]
 pub fn sorted_insert<T: Clone>(
     items: &mut Vec<T>,
     add: T,

--- a/src/utils/sqrt.rs
+++ b/src/utils/sqrt.rs
@@ -8,6 +8,7 @@ use num_traits::Signed;
 /// * `value`: the value for which to compute the square root, rounded down
 ///
 /// returns: BigInt
+#[inline]
 pub fn sqrt(value: &BigInt) -> Result<BigInt, Error> {
     if value.is_negative() {
         Err(Error::Invalid)

--- a/src/utils/validate_and_parse_address.rs
+++ b/src/utils/validate_and_parse_address.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 ///   with only hexadecimal characters after `0x`, returns `Ok(ethereum_address.to_string())`.
 /// * Otherwise, returns an error message in the form of `Err(format!("{} is not a valid Ethereum
 ///   address.", ethereum_address))`.
+#[inline]
 pub fn check_valid_ethereum_address(ethereum_address: &str) -> Result<&str, String> {
     let valid_address_regex = Regex::new(r"^0x[0-9a-fA-F]{40}$").unwrap();
     if valid_address_regex.is_match(ethereum_address) {
@@ -37,6 +38,7 @@ pub fn check_valid_ethereum_address(ethereum_address: &str) -> Result<&str, Stri
 ///   with only hexadecimal characters after `0x`, returns the checksummed address.
 /// * Otherwise, returns an error message in the form of `Err(format!("{} is not a valid Ethereum
 ///   address.", ethereum_address))`.
+#[inline]
 pub fn validate_and_parse_address(ethereum_address: &str) -> Result<String, String> {
     let checksummed_address = eth_checksum::checksum(ethereum_address);
     check_valid_ethereum_address(&checksummed_address)?;


### PR DESCRIPTION
Refactored address mappings to use `AddressMap` and `from_iter` for brevity and readability. This change removes redundant code and improves maintainability. Adjusted constant definitions and function signatures accordingly.