### PR TITLE
feat: add `compute_zksync_create2_address`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
@@ -14,7 +14,7 @@ lazy_static = "1.5"
 num-bigint = "0.4"
 num-integer = "0.1"
 num-traits = "0.2"
-regex = { version = "1.10", optional = true }
+regex = { version = "1.11", optional = true }
 rustc-hash = "2.0"
 thiserror = { version = "1.0", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this to your Cargo.toml
 
 ```
 [dependencies]
-uniswap-sdk-core = "1.0.0"
+uniswap-sdk-core = "2.4.0"
 ```
 
 And this to your code:

--- a/src/utils/compute_zksync_create2_address.rs
+++ b/src/utils/compute_zksync_create2_address.rs
@@ -1,0 +1,44 @@
+use alloy_primitives::{keccak256, Address, Bytes, B256};
+
+#[inline]
+#[must_use]
+pub fn compute_zksync_create2_address(
+    sender: Address,
+    bytecode_hash: B256,
+    salt: B256,
+    input: Option<Bytes>,
+) -> Address {
+    let prefix = keccak256("zksyncCreate2");
+    let input_hash = keccak256(input.unwrap_or_default());
+    let mut bytes = [0; 160];
+    bytes[0..32].copy_from_slice(prefix.as_slice());
+    bytes[44..64].copy_from_slice(sender.as_slice());
+    bytes[64..96].copy_from_slice(salt.as_slice());
+    bytes[96..128].copy_from_slice(bytecode_hash.as_slice());
+    bytes[128..160].copy_from_slice(input_hash.as_slice());
+    Address::from_word(keccak256(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, b256};
+
+    #[test]
+    fn test_compute_zksync_create2_address() {
+        const USDCE: Address = address!("3355df6D4c9C3035724Fd0e3914dE96A5a83aaf4");
+        const WETH: Address = address!("5AEa5775959fBC2557Cc8789bC1bf90A239D9a91");
+        let mut bytes = [0; 96];
+        bytes[12..32].copy_from_slice(USDCE.as_slice());
+        bytes[44..64].copy_from_slice(WETH.as_slice());
+        bytes[92..96].copy_from_slice(3000_u32.to_be_bytes().as_slice());
+        let salt = keccak256(&bytes);
+        let result = compute_zksync_create2_address(
+            address!("8FdA5a7a8dCA67BBcDd10F02Fa0649A937215422"),
+            b256!("010013f177ea1fcbc4520f9a3ca7cd2d1d77959e05aa66484027cb38e712aeed"),
+            salt,
+            None,
+        );
+        assert_eq!(result, address!("ff577f0E828a878743Ecc5E2632cbf65ceCf17cF"));
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,7 @@
 pub mod compute_price_impact;
-
+pub mod compute_zksync_create2_address;
 pub mod sorted_insert;
-
 pub mod sqrt;
+
 #[cfg(feature = "validate_parse_address")]
 pub mod validate_and_parse_address;


### PR DESCRIPTION
Bumped the version in Cargo.toml from 2.3.0 to 2.4.0 and updated the regex dependency. Added a new module to compute zkSync CREATE2 addresses and included tests. Updated the README to reflect the new version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Uniswap SDK Core package to version 2.4.0.
	- Introduced a new function to compute Create2 addresses for zkSync, enhancing address generation capabilities.

- **Documentation**
	- Updated the Quickstart section in the README to reflect the new version of the uniswap-sdk-core dependency. 

- **Bug Fixes**
	- Improved dependency management by updating the regex library to version 1.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->