### PR TITLE
refactor!: consolidate currency-related traits and add `Currency` enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "2.4.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this to your Cargo.toml
 
 ```
 [dependencies]
-uniswap-sdk-core = "2.4.0"
+uniswap-sdk-core = "3.0.0"
 ```
 
 And this to your code:

--- a/src/entities/base_currency.rs
+++ b/src/entities/base_currency.rs
@@ -3,7 +3,21 @@ use alloy_primitives::ChainId;
 
 /// A currency is any fungible financial instrument, including Ether, all ERC20 tokens, and other
 /// chain-native currencies
-pub trait BaseCurrency {
+pub trait BaseCurrency: BaseCurrencyCore + Clone {
+    /// Returns the address of the currency.
+    #[inline]
+    fn address(&self) -> Address {
+        self.wrapped().address
+    }
+
+    /// Returns whether this currency is functionally equivalent to the other currency
+    fn equals(&self, other: &impl BaseCurrency) -> bool;
+
+    /// Returns a Token that represents the wrapped equivalent of the native currency
+    fn wrapped(&self) -> &Token;
+}
+
+pub trait BaseCurrencyCore {
     /// Returns whether the currency is native to the chain and must be wrapped (e.g. Ether)
     fn is_native(&self) -> bool;
 
@@ -23,10 +37,10 @@ pub trait BaseCurrency {
     fn name(&self) -> Option<&String>;
 }
 
-macro_rules! impl_base_currency {
+macro_rules! impl_base_currency_core {
     ($($currency:ty),*) => {
         $(
-            impl<const IS_NATIVE: bool, M> BaseCurrency for $currency {
+            impl<const IS_NATIVE: bool, M> BaseCurrencyCore for $currency {
                 #[inline]
                 fn is_native(&self) -> bool {
                     IS_NATIVE
@@ -61,4 +75,4 @@ macro_rules! impl_base_currency {
     };
 }
 
-impl_base_currency!(CurrencyLike<IS_NATIVE, M>, &CurrencyLike<IS_NATIVE, M>);
+impl_base_currency_core!(CurrencyLike<IS_NATIVE, M>, &CurrencyLike<IS_NATIVE, M>);

--- a/src/entities/ether.rs
+++ b/src/entities/ether.rs
@@ -4,12 +4,12 @@ use crate::prelude::*;
 /// Represents the native currency of the blockchain.
 pub type Ether = CurrencyLike<true, Option<Token>>;
 
-macro_rules! impl_currency {
+macro_rules! impl_base_currency {
     ($($ether:ty),*) => {
         $(
-            impl Currency for $ether {
+            impl BaseCurrency for $ether {
                 #[inline]
-                fn equals(&self, other: &impl Currency) -> bool {
+                fn equals(&self, other: &impl BaseCurrency) -> bool {
                     other.is_native() && self.chain_id() == other.chain_id()
                 }
 
@@ -25,7 +25,7 @@ macro_rules! impl_currency {
     };
 }
 
-impl_currency!(Ether, &Ether);
+impl_base_currency!(Ether, &Ether);
 
 impl Ether {
     /// Creates a new instance of [`Ether`] with the specified chain ID.

--- a/src/entities/fractions/currency_amount.rs
+++ b/src/entities/fractions/currency_amount.rs
@@ -6,14 +6,14 @@ pub type CurrencyAmount<T> = FractionLike<CurrencyMeta<T>>;
 
 /// Struct representing metadata about a currency
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct CurrencyMeta<T: Currency> {
+pub struct CurrencyMeta<T: BaseCurrency> {
     /// The currency associated with this metadata
     pub currency: T,
     /// The scale factor for the currency's decimal places
     pub decimal_scale: BigUint,
 }
 
-impl<T: Currency> CurrencyAmount<T> {
+impl<T: BaseCurrency> CurrencyAmount<T> {
     /// Constructor method for creating a new currency amount
     #[inline]
     fn new(

--- a/src/entities/fractions/price.rs
+++ b/src/entities/fractions/price.rs
@@ -8,8 +8,8 @@ pub type Price<TBase, TQuote> = FractionLike<PriceMeta<TBase, TQuote>>;
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct PriceMeta<TBase, TQuote>
 where
-    TBase: Currency,
-    TQuote: Currency,
+    TBase: BaseCurrency,
+    TQuote: BaseCurrency,
 {
     /// The base currency for the price
     pub base_currency: TBase,
@@ -23,8 +23,8 @@ where
 
 impl<TBase, TQuote> Price<TBase, TQuote>
 where
-    TBase: Currency,
-    TQuote: Currency,
+    TBase: BaseCurrency,
+    TQuote: BaseCurrency,
 {
     /// Constructor for creating a new [`Price`] instance
     #[inline]
@@ -79,7 +79,7 @@ where
     /// Multiply the price by another price, returning a new price.
     /// The other price must have the same base currency as this price's quote currency.
     #[inline]
-    pub fn multiply<TOtherQuote: Currency>(
+    pub fn multiply<TOtherQuote: BaseCurrency>(
         &self,
         other: &Price<TQuote, TOtherQuote>,
     ) -> Result<Price<TBase, TOtherQuote>, Error> {

--- a/src/entities/native_currency.rs
+++ b/src/entities/native_currency.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 /// Represents the native currency of the chain on which it resides
-pub trait NativeCurrency: BaseCurrency {
+pub trait NativeCurrency: BaseCurrencyCore {
     #[inline]
     fn is_native(&self) -> bool {
         true

--- a/src/entities/token.rs
+++ b/src/entities/token.rs
@@ -14,12 +14,12 @@ pub struct TokenMeta {
     pub sell_fee_bps: Option<BigUint>,
 }
 
-macro_rules! impl_currency {
+macro_rules! impl_base_currency {
     ($($token:ty),*) => {
         $(
-            impl Currency for $token {
+            impl BaseCurrency for $token {
                 #[inline]
-                fn equals(&self, other: &impl Currency) -> bool {
+                fn equals(&self, other: &impl BaseCurrency) -> bool {
                     other.is_token() && self.chain_id == other.chain_id() && self.address == other.address()
                 }
 
@@ -32,7 +32,7 @@ macro_rules! impl_currency {
     };
 }
 
-impl_currency!(Token, &Token);
+impl_base_currency!(Token, &Token);
 
 impl Token {
     /// Creates a new [`Token`] with the given parameters.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,8 +3,8 @@ pub use crate::{
     chains::*,
     constants::*,
     entities::{
-        base_currency::BaseCurrency,
-        currency::{Currency, CurrencyLike},
+        base_currency::*,
+        currency::*,
         ether::Ether,
         fractions::{
             currency_amount::CurrencyAmount,

--- a/src/utils/compute_price_impact.rs
+++ b/src/utils/compute_price_impact.rs
@@ -10,7 +10,7 @@ use crate::prelude::*;
 ///
 /// returns: Percent
 #[inline]
-pub fn compute_price_impact<TBase: Currency, TQuote: Currency>(
+pub fn compute_price_impact<TBase: BaseCurrency, TQuote: BaseCurrency>(
     mid_price: &Price<TBase, TQuote>,
     input_amount: &CurrencyAmount<TBase>,
     output_amount: &CurrencyAmount<TQuote>,


### PR DESCRIPTION
Reorganized `BaseCurrency` and `BaseCurrencyCore` traits, encapsulating their functionalities. Introduced `Currency` enum to represent both native and token currencies, providing a unified interface for currency operations. Updated version to 3.0.0 to reflect these breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated package version for `uniswap-sdk-core` from 2.4.0 to 3.0.0.
  - Enhanced currency representation with new `BaseCurrencyCore` and `BaseCurrency` traits.
  - Introduced a new `Currency` enum to simplify currency handling.

- **Bug Fixes**
  - Adjusted type constraints in various structures and implementations to ensure compatibility with the new base currency model.

- **Documentation**
  - Updated `README.md` to reflect the new version of `uniswap-sdk-core`.

- **Chores**
  - Consolidated module imports in `src/prelude.rs` for easier access to public items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->