### PR TITLE
refactor: add `derive_more` and adjust imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [dependencies]
 alloy-primitives = "0.8"
 bigdecimal = "0.4.5"
+derive_more = { version = "1.0.0", features = ["deref"] }
 eth_checksum = { version = "0.1.2", optional = true }
 lazy_static = "1.5"
 num-bigint = "0.4"

--- a/src/entities/currency.rs
+++ b/src/entities/currency.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use alloy_primitives::ChainId;
+use derive_more::Deref;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Currency {
@@ -9,7 +10,7 @@ pub enum Currency {
 
 /// [`CurrencyLike`] is a generic struct representing a currency with a specific chain ID,
 /// decimals, symbol, name, and additional metadata.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Deref)]
 pub struct CurrencyLike<const IS_NATIVE: bool, M> {
     /// The chain ID on which this currency resides
     pub chain_id: ChainId,
@@ -24,17 +25,8 @@ pub struct CurrencyLike<const IS_NATIVE: bool, M> {
     pub name: Option<String>,
 
     /// Metadata associated with the currency
+    #[deref]
     pub meta: M,
-}
-
-/// Implement [`Deref`] to allow direct access to the metadata of the currency
-impl<const IS_NATIVE: bool, M> Deref for CurrencyLike<IS_NATIVE, M> {
-    type Target = M;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.meta
-    }
 }
 
 macro_rules! match_currency_method {

--- a/src/entities/fractions/currency_amount.rs
+++ b/src/entities/fractions/currency_amount.rs
@@ -1,5 +1,5 @@
-/// External crate dependencies
 use crate::prelude::*;
+use core::ops::Div;
 
 /// Currency amount struct that represents a rational amount of a currency
 pub type CurrencyAmount<T> = FractionLike<CurrencyMeta<T>>;

--- a/src/entities/fractions/fraction.rs
+++ b/src/entities/fractions/fraction.rs
@@ -1,15 +1,17 @@
 use crate::prelude::*;
 use core::{
     hash::{Hash, Hasher},
-    ops::{Add, Deref, Mul, Sub},
+    ops::{Add, Div, Mul, Sub},
 };
+use derive_more::Deref;
 
 /// Struct representing a fraction with metadata
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deref)]
 pub struct FractionLike<M> {
     pub numerator: BigInt,
     pub denominator: BigInt,
     /// Metadata associated with the fraction
+    #[deref]
     pub meta: M,
 }
 
@@ -21,16 +23,6 @@ impl<M: Default> Default for FractionLike<M> {
             denominator: BigInt::from(1),
             meta: M::default(),
         }
-    }
-}
-
-/// Implement [`Deref`] to allow direct access to the metadata of the fraction
-impl<M> Deref for FractionLike<M> {
-    type Target = M;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.meta
     }
 }
 

--- a/src/entities/fractions/price.rs
+++ b/src/entities/fractions/price.rs
@@ -1,4 +1,3 @@
-/// External crate dependencies
 use crate::prelude::*;
 
 /// Type alias for a Price, a [`FractionLike`] with metadata [`PriceMeta`]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,12 +25,7 @@ pub use alloc::{
 };
 pub use alloy_primitives::{address, Address};
 pub use bigdecimal::{BigDecimal, RoundingMode};
-pub use core::{
-    cmp::Ordering,
-    num::NonZeroU64,
-    ops::{Deref, Div},
-    str::FromStr,
-};
+pub use core::{cmp::Ordering, num::NonZeroU64, str::FromStr};
 pub use lazy_static::lazy_static;
 pub use num_bigint::{BigInt, BigUint, ToBigInt, ToBigUint};
 pub use num_integer::Integer;


### PR DESCRIPTION
Integrated `derive_more` for `Deref` attribute across various structs and adjusted the core module imports accordingly. This helps in simplifying the code and reducing redundancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Price` type for handling currency prices with various methods for creation, multiplication, and conversion.
	- Added support for division operations across several currency-related structures.

- **Bug Fixes**
	- Enhanced error handling in currency operations to prevent exceeding maximum limits.

- **Refactor**
	- Streamlined the implementation of dereferencing behavior in currency structures.

- **Tests**
	- Added tests for the new `Price` struct and its methods to ensure functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->