### PR TITLE
feat: add `From` derive to `Currency` enum

### DIFF
--- a/src/entities/currency.rs
+++ b/src/entities/currency.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 use alloy_primitives::ChainId;
-use derive_more::Deref;
+use derive_more::{Deref, From};
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, From)]
 pub enum Currency {
     NativeCurrency(Ether),
     Token(Token),


### PR DESCRIPTION
This update adds the `From` derive to the `Currency` enum to enable more convenient type conversions. It facilitates smoother integration by allowing conversions directly from component types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `Currency` enum functionality with the addition of the `From` derive macro, facilitating easier conversions.
  
- **Bug Fixes**
	- No changes made; existing functionality remains intact. 

- **Documentation**
	- No updates to documentation noted. 

- **Tests**
	- Test module remains unchanged, ensuring existing tests for `Currency` and `Ether` continue to function as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->