### PR TITLE
refactor!: change rounding parameters to use defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,12 +13,13 @@ pub enum TradeType {
 }
 
 /// Represents three various ways to round
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub enum Rounding {
     /// Rounds down to the nearest whole number.
     RoundDown,
 
     /// Rounds to the nearest whole number, rounding halfway cases away from zero.
+    #[default]
     RoundHalfUp,
 
     /// Rounds up to the nearest whole number.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,10 +16,10 @@ pub enum TradeType {
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub enum Rounding {
     /// Rounds down to the nearest whole number.
-    #[default]
     RoundDown,
 
     /// Rounds to the nearest whole number, rounding halfway cases away from zero.
+    #[default]
     RoundHalfUp,
 
     /// Rounds up to the nearest whole number.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,10 +16,10 @@ pub enum TradeType {
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub enum Rounding {
     /// Rounds down to the nearest whole number.
+    #[default]
     RoundDown,
 
     /// Rounds to the nearest whole number, rounding halfway cases away from zero.
-    #[default]
     RoundHalfUp,
 
     /// Rounds up to the nearest whole number.

--- a/src/entities/fractions/fraction.rs
+++ b/src/entities/fractions/fraction.rs
@@ -121,11 +121,15 @@ pub trait FractionBase<M: Clone>: Sized {
     /// Converts the fraction to a string with a specified number of significant digits and rounding
     /// strategy
     #[inline]
-    fn to_significant(&self, significant_digits: u8, rounding: Rounding) -> Result<String, Error> {
+    fn to_significant(
+        &self,
+        significant_digits: u8,
+        rounding: Option<Rounding>,
+    ) -> Result<String, Error> {
         if significant_digits == 0 {
             return Err(Error::Invalid("SIGNIFICANT_DIGITS"));
         }
-        let rounding_strategy = to_rounding_strategy(rounding);
+        let rounding_strategy = to_rounding_strategy(rounding.unwrap_or_default());
         let quotient = self.to_decimal().with_precision_round(
             NonZeroU64::new(significant_digits as u64).unwrap(),
             rounding_strategy,
@@ -137,8 +141,8 @@ pub trait FractionBase<M: Clone>: Sized {
     /// Converts the fraction to a string with a fixed number of decimal places and rounding
     /// strategy
     #[inline]
-    fn to_fixed(&self, decimal_places: u8, rounding: Rounding) -> String {
-        let rounding_strategy = to_rounding_strategy(rounding);
+    fn to_fixed(&self, decimal_places: u8, rounding: Option<Rounding>) -> String {
+        let rounding_strategy = to_rounding_strategy(rounding.unwrap_or_default());
         self.to_decimal()
             .with_scale_round(decimal_places as i64, rounding_strategy)
             .to_string()
@@ -158,7 +162,6 @@ impl<M: Clone> FractionBase<M> for FractionLike<M> {
     #[inline]
     fn new(numerator: impl Into<BigInt>, denominator: impl Into<BigInt>, meta: M) -> Self {
         let denominator = denominator.into();
-        // Ensure the denominator is not zero
         assert!(!denominator.is_zero(), "denominator is zero");
         Self {
             numerator: numerator.into(),

--- a/src/entities/fractions/percent.rs
+++ b/src/entities/fractions/percent.rs
@@ -24,10 +24,8 @@ impl Percent {
     pub fn to_significant(
         &self,
         significant_digits: u8,
-        rounding: Rounding,
+        rounding: Option<Rounding>,
     ) -> Result<String, Error> {
-        // Convert the Percent to a simple Fraction, multiply by 100, and then call to_significant
-        // on the result
         (self.as_fraction() * ONE_HUNDRED.as_fraction())
             .to_significant(significant_digits, rounding)
     }
@@ -36,9 +34,7 @@ impl Percent {
     /// strategy
     #[inline]
     #[must_use]
-    pub fn to_fixed(&self, decimal_places: u8, rounding: Rounding) -> String {
-        // Convert the Percent to a simple Fraction, multiply by 100, and then call to_fixed on the
-        // result
+    pub fn to_fixed(&self, decimal_places: u8, rounding: Option<Rounding>) -> String {
         (self.as_fraction() * ONE_HUNDRED.as_fraction()).to_fixed(decimal_places, rounding)
     }
 }
@@ -98,9 +94,7 @@ mod tests {
     #[test]
     fn test_to_significant() {
         assert_eq!(
-            Percent::new(154, 10000)
-                .to_significant(3, Rounding::RoundHalfUp)
-                .unwrap(),
+            Percent::new(154, 10000).to_significant(3, None).unwrap(),
             "1.54".to_string()
         );
     }
@@ -108,7 +102,7 @@ mod tests {
     #[test]
     fn test_to_fixed() {
         assert_eq!(
-            Percent::new(154, 10000).to_fixed(2, Rounding::RoundHalfUp),
+            Percent::new(154, 10000).to_fixed(2, None),
             "1.54".to_string()
         );
     }


### PR DESCRIPTION
This commit updates the rounding parameters in multiple modules to use `Option<Rounding>` with a default value if none is specified. This change simplifies method calls and improves code flexibility by allowing optional rounding strategies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced flexibility in rounding parameters across various methods, allowing users to specify `None` for rounding in `CurrencyAmount`, `FractionBase`, `Percent`, and `Price` structs.

- **Bug Fixes**
	- Improved handling of default rounding strategies in methods where rounding may not be specified.

- **Documentation**
	- Updated test cases to reflect changes in method signatures and ensure comprehensive coverage of new optional rounding functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->