### PR TITLE
perf!: refactor types and replace `num-bigint` with `fastnum`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "3.3.0"
+version = "4.0.0-rc"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
@@ -8,17 +8,16 @@ license = "MIT"
 
 [dependencies]
 alloy-primitives = { version = ">=0.8.5", features = ["map-fxhash"] }
-bigdecimal = "0.4.5"
 derive_more = { version = "1.0.0", features = ["deref"] }
 eth_checksum = { version = "0.1.2", optional = true }
+fastnum = { version = "0.1.9", default-features = false, features = ["libm"] }
 lazy_static = "1.5"
-num-bigint = "0.4"
-num-integer = "0.1"
 regex = { version = "1.11", optional = true }
 thiserror = { version = "2", default-features = false }
 
 [features]
-std = ["thiserror/std"]
+default = []
+std = ["fastnum/std", "thiserror/std"]
 validate_parse_address = ["eth_checksum", "regex"]
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your Cargo.toml
 
 ```
 [dependencies]
-uniswap-sdk-core = "3.3.0"
+uniswap-sdk-core = "4.0.0"
 ```
 
 And this to your code:

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
 use alloy_primitives::U256;
-use lazy_static::lazy_static;
-use num_bigint::Sign;
 
 /// Represents the various types of trades.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -27,8 +25,5 @@ pub enum Rounding {
     RoundUp,
 }
 
-lazy_static! {
-    /// Represents the maximum amount contained in a uint256
-    pub static ref MAX_UINT256: BigInt =
-        BigInt::from_biguint(Sign::Plus, BigUint::from_bytes_le(&U256::MAX.as_le_bytes()));
-}
+/// Represents the maximum amount contained in a uint256
+pub const MAX_UINT256: BigInt = to_big_int(U256::MAX);

--- a/src/entities/fractions/price.rs
+++ b/src/entities/fractions/price.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use fastnum::i512;
 
 /// Type alias for a Price, a [`FractionLike`] with metadata [`PriceMeta`]
 pub type Price<TBase, TQuote> = FractionLike<PriceMeta<TBase, TQuote>>;
@@ -35,8 +36,8 @@ where
     ) -> Self {
         // Calculate scalar based on decimal places of base and quote currencies
         let scalar = Fraction::new(
-            BigInt::from(10).pow(base_currency.decimals() as u32),
-            BigInt::from(10).pow(quote_currency.decimals() as u32),
+            i512!(10).pow(base_currency.decimals() as u32),
+            i512!(10).pow(quote_currency.decimals() as u32),
         );
         FractionBase::new(
             numerator,
@@ -70,8 +71,8 @@ where
         Price::new(
             self.quote_currency.clone(),
             self.base_currency.clone(),
-            self.numerator.clone(),
-            self.denominator.clone(),
+            self.numerator,
+            self.denominator,
         )
     }
 

--- a/src/entities/token.rs
+++ b/src/entities/token.rs
@@ -4,14 +4,14 @@ use crate::prelude::*;
 pub type Token = CurrencyLike<false, TokenMeta>;
 
 /// Represents the metadata for an ERC20 token, including its address and optional fees.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct TokenMeta {
     /// The address of the token.
     pub address: Address,
     /// The buy fee in basis points (bps) for the token.
-    pub buy_fee_bps: Option<BigUint>,
+    pub buy_fee_bps: u64,
     /// The sell fee in basis points (bps) for the token.
-    pub sell_fee_bps: Option<BigUint>,
+    pub sell_fee_bps: u64,
 }
 
 macro_rules! impl_base_currency {
@@ -62,8 +62,8 @@ impl Token {
         decimals: u8,
         symbol: Option<String>,
         name: Option<String>,
-        buy_fee_bps: Option<BigUint>,
-        sell_fee_bps: Option<BigUint>,
+        buy_fee_bps: u64,
+        sell_fee_bps: u64,
     ) -> Self {
         assert!(chain_id != 0, "chain id can't be zero");
         Self {
@@ -135,8 +135,8 @@ macro_rules! token {
             $decimals,
             None,
             None,
-            None,
-            None,
+            0,
+            0,
         )
     };
     ($chain_id:expr, $address:expr, $decimals:expr) => {
@@ -146,8 +146,8 @@ macro_rules! token {
             $decimals,
             None,
             None,
-            None,
-            None,
+            0,
+            0,
         )
     };
     ($chain_id:expr, $address:literal, $decimals:expr, $symbol:expr) => {
@@ -157,8 +157,8 @@ macro_rules! token {
             $decimals,
             Some($symbol.to_string()),
             None,
-            None,
-            None,
+            0,
+            0,
         )
     };
     ($chain_id:expr, $address:expr, $decimals:expr, $symbol:expr) => {
@@ -168,8 +168,8 @@ macro_rules! token {
             $decimals,
             Some($symbol.to_string()),
             None,
-            None,
-            None,
+            0,
+            0,
         )
     };
     ($chain_id:expr, $address:literal, $decimals:expr, $symbol:expr, $name:expr) => {
@@ -179,8 +179,8 @@ macro_rules! token {
             $decimals,
             Some($symbol.to_string()),
             Some($name.to_string()),
-            None,
-            None,
+            0,
+            0,
         )
     };
     ($chain_id:expr, $address:expr, $decimals:expr, $symbol:expr, $name:expr) => {
@@ -190,8 +190,8 @@ macro_rules! token {
             $decimals,
             Some($symbol.to_string()),
             Some($name.to_string()),
-            None,
-            None,
+            0,
+            0,
         )
     };
 }

--- a/src/examples/token_example.rs
+++ b/src/examples/token_example.rs
@@ -12,8 +12,8 @@ fn main() {
         18, // Decimals for DAI
         Some("DAI".to_string()), // Symbol for DAI
         Some("Dai Stablecoin".to_string()), // Name for DAI
-        None, // Assuming no buy fee
-        None, // Assuming no sell fee
+        0, // Assuming no buy fee
+        0, // Assuming no sell fee
     );
 
     // Print the token's address and decimals

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub mod prelude {
 
     pub type BigInt = fastnum::I512;
     pub type BigUint = fastnum::U512;
-    pub type BigDecimal = fastnum::UD512;
+    pub type BigDecimal = fastnum::D512;
     pub type RoundingMode = fastnum::decimal::RoundingMode;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,10 +49,10 @@ pub mod prelude {
     pub use alloc::{string::String, vec::Vec};
     pub use alloy_primitives::{map::rustc_hash::FxHashMap, Address, Bytes, B256, U256};
 
-    pub type BigInt = num_bigint::BigInt;
-    pub type BigUint = num_bigint::BigUint;
-    pub type BigDecimal = bigdecimal::BigDecimal;
-    pub type RoundingMode = bigdecimal::RoundingMode;
+    pub type BigInt = fastnum::I512;
+    pub type BigUint = fastnum::U512;
+    pub type BigDecimal = fastnum::UD512;
+    pub type RoundingMode = fastnum::decimal::RoundingMode;
 }
 
 /// Contains examples of how Uniswap sdk core can be used

--- a/src/utils/compute_zksync_create2_address.rs
+++ b/src/utils/compute_zksync_create2_address.rs
@@ -32,7 +32,7 @@ mod tests {
         bytes[12..32].copy_from_slice(USDCE.as_slice());
         bytes[44..64].copy_from_slice(WETH.as_slice());
         bytes[92..96].copy_from_slice(3000_u32.to_be_bytes().as_slice());
-        let salt = keccak256(&bytes);
+        let salt = keccak256(bytes);
         let result = compute_zksync_create2_address(
             address!("8FdA5a7a8dCA67BBcDd10F02Fa0649A937215422"),
             b256!("010013f177ea1fcbc4520f9a3ca7cd2d1d77959e05aa66484027cb38e712aeed"),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,11 +2,13 @@ pub mod compute_price_impact;
 pub mod compute_zksync_create2_address;
 pub mod sorted_insert;
 pub mod sqrt;
+mod types;
 
 pub use compute_price_impact::compute_price_impact;
 pub use compute_zksync_create2_address::compute_zksync_create2_address;
 pub use sorted_insert::sorted_insert;
 pub use sqrt::sqrt;
+pub use types::*;
 
 #[cfg(feature = "validate_parse_address")]
 pub mod validate_and_parse_address;

--- a/src/utils/sqrt.rs
+++ b/src/utils/sqrt.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use fastnum::i512;
 
 /// Computes floor(sqrt(value))
 ///
@@ -8,25 +9,34 @@ use crate::prelude::*;
 ///
 /// returns: BigInt
 #[inline]
-pub fn sqrt(value: &BigInt) -> Result<BigInt, Error> {
-    if value < &BigInt::ZERO {
-        Err(Error::Invalid("NEGATIVE"))
-    } else {
-        Ok(value.sqrt())
+pub fn sqrt(value: BigInt) -> Result<BigInt, Error> {
+    const ONE: BigInt = i512!(1);
+    const TWO: BigInt = i512!(2);
+    match value {
+        v if v < BigInt::ZERO => Err(Error::Invalid("NEGATIVE")),
+        BigInt::ZERO => Ok(BigInt::ZERO),
+        v if v <= TWO => Ok(ONE),
+        _ => {
+            let mut z = value;
+            let mut x = (value / TWO) + ONE;
+            while x < z {
+                z = x;
+                x = (value / x + x) / TWO;
+            }
+            Ok(z)
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::str::FromStr;
 
     #[test]
     fn test_sqrt_0_1000() {
         for i in 0..1000 {
-            let sqrt_i = sqrt(&BigInt::from(i));
             assert_eq!(
-                sqrt_i.unwrap(),
+                sqrt(BigInt::from(i)).unwrap(),
                 BigInt::from((i as f64).sqrt().floor() as i64)
             );
         }
@@ -36,14 +46,14 @@ mod tests {
     fn test_sqrt_2_powers() {
         for i in 0..256 {
             let root = BigInt::from(2).pow(i as u32);
-            let root_squared = &root * &root;
-            assert_eq!(sqrt(&root_squared).unwrap(), root);
+            let root_squared = root * root;
+            assert_eq!(sqrt(root_squared).unwrap(), root);
         }
     }
 
     #[test]
     fn test_sqrt_max_uint256() {
-        let expected_sqrt = BigInt::from_str("340282366920938463463374607431768211455").unwrap();
-        assert_eq!(sqrt(&MAX_UINT256.clone()).unwrap(), expected_sqrt);
+        let expected_sqrt = i512!(340282366920938463463374607431768211455);
+        assert_eq!(sqrt(MAX_UINT256).unwrap(), expected_sqrt);
     }
 }

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -1,11 +1,14 @@
 use crate::prelude::{BigDecimal, BigInt, BigUint};
 use alloy_primitives::U256;
-use fastnum::decimal::Context;
+use fastnum::decimal::{Context, Sign};
 
 #[inline]
 #[must_use]
 pub const fn to_big_decimal(value: BigInt) -> BigDecimal {
-    BigDecimal::from_parts(value.to_bits(), 0, Context::default())
+    match value.is_negative() {
+        false => BigDecimal::from_parts(value.to_bits(), 0, Sign::Plus, Context::default()),
+        true => BigDecimal::from_parts(value.to_bits(), 0, Sign::Minus, Context::default()),
+    }
 }
 
 #[inline]

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -1,0 +1,21 @@
+use crate::prelude::{BigDecimal, BigInt, BigUint};
+use alloy_primitives::U256;
+use fastnum::decimal::Context;
+
+#[inline]
+#[must_use]
+pub const fn to_big_decimal(value: BigInt) -> BigDecimal {
+    BigDecimal::from_parts(value.to_bits(), 0, Context::default())
+}
+
+#[inline]
+#[must_use]
+pub const fn to_big_uint(x: U256) -> BigUint {
+    BigUint::from_le_slice(x.as_le_slice()).unwrap()
+}
+
+#[inline]
+#[must_use]
+pub const fn to_big_int(x: U256) -> BigInt {
+    BigInt::from_bits(to_big_uint(x))
+}


### PR DESCRIPTION
Replace `num-bigint` and `bigdecimal` with `fastnum` for improved performance and simplified arithmetic operations. Updated `Cargo.toml`, core types, and utility functions to utilize `fastnum`'s features and refined the API for consistency. This commits also includes enhancements in test cases and clean-ups for derived constants and methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for new numeric types using `fastnum` library.
	- Introduced new utility functions for type conversions.

- **Breaking Changes**
	- Updated package version to `4.0.0-rc`.
	- Modified token fee handling from optional to fixed values.
	- Changed type representations for big numbers and decimals.

- **Improvements**
	- Enhanced square root calculation algorithm.
	- Simplified type handling and conversions.
	- Optimized performance for large number operations.

- **Dependency Changes**
	- Removed `bigdecimal`, `num-bigint`, and `num-integer`.
	- Added `fastnum` dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->