### PR TITLE
fix: reduce big int overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 alloy-primitives = { version = ">=0.8.5", features = ["map-fxhash"] }
 derive_more = { version = "1.0.0", features = ["deref"] }
 eth_checksum = { version = "0.1.2", optional = true }
-fastnum = { version = "0.1.9", default-features = false, features = ["libm"] }
+fastnum = { version = "0.1.9", default-features = false, features = ["libm", "numtraits"] }
 lazy_static = "1.5"
+num-integer = "0.1.46"
 regex = { version = "1.11", optional = true }
 thiserror = { version = "2", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 
 [dependencies]
 alloy-primitives = { version = ">=0.8.5", features = ["map-fxhash"] }
+bnum = "0.12.0"
 derive_more = { version = "1.0.0", features = ["deref"] }
 eth_checksum = { version = "0.1.2", optional = true }
 fastnum = { version = "0.1.9", default-features = false, features = ["libm", "numtraits"] }

--- a/src/entities/token.rs
+++ b/src/entities/token.rs
@@ -142,7 +142,10 @@ macro_rules! token {
     ($chain_id:expr, $address:expr, $decimals:expr) => {
         Token::new(
             $chain_id,
-            $address.to_string().parse::<Address>().unwrap(),
+            $address
+                .to_string()
+                .parse::<alloy_primitives::Address>()
+                .unwrap(),
             $decimals,
             None,
             None,
@@ -164,7 +167,10 @@ macro_rules! token {
     ($chain_id:expr, $address:expr, $decimals:expr, $symbol:expr) => {
         Token::new(
             $chain_id,
-            $address.to_string().parse::<Address>().unwrap(),
+            $address
+                .to_string()
+                .parse::<alloy_primitives::Address>()
+                .unwrap(),
             $decimals,
             Some($symbol.to_string()),
             None,
@@ -186,7 +192,10 @@ macro_rules! token {
     ($chain_id:expr, $address:expr, $decimals:expr, $symbol:expr, $name:expr) => {
         Token::new(
             $chain_id,
-            $address.to_string().parse::<Address>().unwrap(),
+            $address
+                .to_string()
+                .parse::<alloy_primitives::Address>()
+                .unwrap(),
             $decimals,
             Some($symbol.to_string()),
             Some($name.to_string()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ pub mod prelude {
 
     pub use alloc::{string::String, vec::Vec};
     pub use alloy_primitives::{map::rustc_hash::FxHashMap, Address, Bytes, B256, U256};
+    pub use bnum;
+    pub use num_integer::Integer;
 
     pub type BigInt = fastnum::I512;
     pub type BigUint = fastnum::U512;

--- a/src/utils/sqrt.rs
+++ b/src/utils/sqrt.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use fastnum::i512;
+use num_integer::Roots;
 
 /// Computes floor(sqrt(value))
 ///
@@ -10,27 +10,17 @@ use fastnum::i512;
 /// returns: BigInt
 #[inline]
 pub fn sqrt(value: BigInt) -> Result<BigInt, Error> {
-    const ONE: BigInt = i512!(1);
-    const TWO: BigInt = i512!(2);
-    match value {
-        v if v < BigInt::ZERO => Err(Error::Invalid("NEGATIVE")),
-        BigInt::ZERO => Ok(BigInt::ZERO),
-        v if v <= TWO => Ok(ONE),
-        _ => {
-            let mut z = value;
-            let mut x = (value / TWO) + ONE;
-            while x < z {
-                z = x;
-                x = (value / x + x) / TWO;
-            }
-            Ok(z)
-        }
+    if value < BigInt::ZERO {
+        Err(Error::Invalid("NEGATIVE"))
+    } else {
+        Ok(value.sqrt())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fastnum::i512;
 
     #[test]
     fn test_sqrt_0_1000() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Dependencies**
  - Added new dependencies: `bnum` and `num-integer`
  - Updated `fastnum` dependency to include additional features

- **Improvements**
  - Enhanced precision for fraction calculations
  - Simplified square root computation using `num-integer`
  - Updated token address parsing to use `alloy_primitives`

- **SDK Exports**
  - Exposed `bnum` and `Integer` trait in the prelude module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->