### PR TITLE
chore: re-export `fastnum` and update crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "4.0.0-rc"
+version = "4.0.0-rc1"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod prelude {
     pub use alloc::{string::String, vec::Vec};
     pub use alloy_primitives::{map::rustc_hash::FxHashMap, Address, Bytes, B256, U256};
     pub use bnum;
+    pub use fastnum;
     pub use num_integer::Integer;
 
     pub type BigInt = fastnum::I512;


### PR DESCRIPTION
`fastnum` is now included to support the `BigInt` type via `fastnum::I512`. Updated the version in `Cargo.toml` from `4.0.0-rc` to `4.0.0-rc1` to reflect the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated `fastnum` library for enhanced numerical handling
	- Updated type aliases for BigInt, BigUint, BigDecimal, and RoundingMode

- **Chores**
	- Incremented package version from `4.0.0-rc` to `4.0.0-rc1`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->