### PR TITLE
feat: add `ToBig` trait implementation for `BigDecimal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "4.0.0-rc1"
+version = "4.0.0-rc2"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"


### PR DESCRIPTION
Implemented `to_big_uint`, `to_big_int`, and `to_big_decimal` methods for `BigDecimal` in `ToBig` trait. Added comprehensive tests to validate the behavior of these methods, covering both positive and negative cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package version from `4.0.0-rc1` to `4.0.0-rc2`

- **New Features**
	- Enhanced `BigDecimal` type conversion methods
	- Added new conversion methods for `BigDecimal` to `BigUint` and `BigInt`

- **Tests**
	- Added test coverage for decimal type conversions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->