### PR TITLE
feat: add `wrapped_owned` method to `CurrencyAmount`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "3.3.0"
+version = "3.4.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 alloy-primitives = { version = ">=0.8.5", features = ["map-fxhash"] }
-bigdecimal = "0.4.5"
+bigdecimal = "0.4.7"
 derive_more = { version = "1.0.0", features = ["deref"] }
 eth_checksum = { version = "0.1.2", optional = true }
 lazy_static = "1.5"

--- a/src/entities/fractions/currency_amount.rs
+++ b/src/entities/fractions/currency_amount.rs
@@ -150,6 +150,16 @@ impl<T: BaseCurrency> CurrencyAmount<T> {
             self.denominator().clone(),
         )
     }
+
+    /// Wrap the currency amount if the currency is not native
+    #[inline]
+    pub fn wrapped_owned(&self) -> Result<CurrencyAmount<Token>, Error> {
+        CurrencyAmount::from_fractional_amount(
+            self.currency.wrapped().clone(),
+            self.numerator().clone(),
+            self.denominator().clone(),
+        )
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Updated Cargo.toml to version 3.4.0 and upgraded the `bigdecimal` dependency to version 0.4.7. Added a new `wrapped_owned` method in `CurrencyAmount` for better handling of wrapped currencies.