### PR TITLE
feat: add `wrapped_owned` method to `CurrencyAmount`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "4.0.0-rc2"
+version = "4.0.0-rc3"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"

--- a/src/entities/fractions/currency_amount.rs
+++ b/src/entities/fractions/currency_amount.rs
@@ -150,6 +150,16 @@ impl<T: BaseCurrency> CurrencyAmount<T> {
             self.denominator(),
         )
     }
+
+    /// Wrap the currency amount if the currency is not native
+    #[inline]
+    pub fn wrapped_owned(&self) -> Result<CurrencyAmount<Token>, Error> {
+        CurrencyAmount::from_fractional_amount(
+            self.currency.wrapped().clone(),
+            self.numerator(),
+            self.denominator(),
+        )
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Introduced `wrapped_owned` to wrap non-native currency amounts into `CurrencyAmount<Token>`. Also updated `Cargo.toml` to version `4.0.0-rc3` to reflect the new changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `wrapped_owned` method to `CurrencyAmount` for creating an owned wrapped currency amount

- **Chores**
	- Updated package version from `4.0.0-rc2` to `4.0.0-rc3`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->