### PR TITLE
chore: update version and fastnum dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "4.0.0-rc5"
+version = "4.0.0-rc6"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
@@ -16,7 +16,7 @@ alloy-primitives = { version = ">=0.8.5", default-features = false, features = [
 bnum = "0.12.0"
 derive_more = { version = "2", default-features = false, features = ["deref", "from"] }
 eth_checksum = { version = "0.1.2", optional = true }
-fastnum = { version = "0.1.11", default-features = false, features = ["numtraits"] }
+fastnum = { version = "0.2.1", default-features = false, features = ["numtraits"] }
 lazy_static = "1.5"
 num-integer = { version = "0.1", default-features = false }
 num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }


### PR DESCRIPTION
Bump package version from 4.0.0-rc5 to 4.0.0-rc6 and upgrade fastnum from 0.1.11 to 0.2.1. These updates ensure compatibility with the latest features and improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the package to version 4.0.0-rc6.
	- Upgraded a core dependency to enhance stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->