### PR TITLE
Fix uniswap-v3-sdk and uniswap-v4-sdk complation issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["sdk-core", "ethereum", "sdk"]
 exclude = [".github", ".gitignore", "rustfmt.toml"]
 
 [dependencies]
-alloy-primitives = { version = ">=0.8.5", default-features = false, features = ["map-fxhash"] }
+alloy-primitives = { version = "^0.8.5", default-features = false, features = ["map-fxhash"] }
 bnum = "0.12.0"
 derive_more = { version = "2", default-features = false, features = ["deref", "from"] }
 eth_checksum = { version = "0.1.2", optional = true }


### PR DESCRIPTION
uniswap-v3-sdk doesn't compile due to alloy-primitives 1.0.0 release which is used by uniswap-sdk-core implicitly in `>=0.8.5`. 

I think the intention was `^0.8.5`. The current setup caused upstream dependancies to no longer compile.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated underlying library compatibility settings for improved consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->