### PR TITLE
chore: bump `alloy-primitives` to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "4.0.1"
+version = "5.0.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
@@ -12,11 +12,11 @@ keywords = ["sdk-core", "ethereum", "sdk"]
 exclude = [".github", ".gitignore", "rustfmt.toml"]
 
 [dependencies]
-alloy-primitives = { version = "^0.8.5", default-features = false, features = ["map-fxhash"] }
+alloy-primitives = { version = "1.0", default-features = false, features = ["map-fxhash"] }
 bnum = "0.12.0"
 derive_more = { version = "2", default-features = false, features = ["deref", "from"] }
 eth_checksum = { version = "0.1.2", optional = true }
-fastnum = { version = "0.2.2", default-features = false, features = ["numtraits"] }
+fastnum = { version = "0.2.3", default-features = false, features = ["numtraits"] }
 lazy_static = "1.5"
 num-integer = { version = "0.1", default-features = false }
 num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your Cargo.toml
 
 ```toml
 [dependencies]
-uniswap-sdk-core = "4.0.0"
+uniswap-sdk-core = "5.0.0"
 ```
 
 And this to your code:
@@ -35,7 +35,7 @@ the `token!` macro.
 <details>
   <summary>Click to expand</summary>
 
-```rust
+```rust,ignore
 // Import necessary preludes and token macro
 use uniswap_sdk_core::{prelude::*, token};
 


### PR DESCRIPTION
Upgraded `alloy-primitives` to 1.0 and `fastnum` to 0.2.3. Updated `uniswap-sdk-core` dependency in README and bumped crate version to 5.0.0 in `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the application to a new major version.
  - Updated several key dependencies for enhanced performance and stability.
- **Documentation**
  - Refined code examples to improve clarity and guide usage more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->