### PR TITLE
feat: make `ChainAddresses` fields public and add support for Soneium

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "5.0.0"
+version = "5.1.0"
 edition = "2021"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
 description = "The Uniswap SDK Core in Rust provides essential functionality for interacting with the Uniswap decentralized exchange"
@@ -25,5 +25,14 @@ thiserror = { version = "2", default-features = false }
 
 [features]
 default = []
-std = ["alloy-primitives/std", "derive_more/std", "fastnum/std", "num-integer/std", "thiserror/std"]
-validate_parse_address = ["eth_checksum", "regex"]
+std = [
+    "alloy-primitives/std",
+    "derive_more/std",
+    "fastnum/std",
+    "num-integer/std",
+    "thiserror/std"
+]
+validate_parse_address = [
+    "eth_checksum",
+    "regex"
+]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Uniswap SDK Core Rust
 
 [![Rust CI](https://github.com/malik672/uniswap-sdk-core-rust/actions/workflows/rust.yml/badge.svg)](https://github.com/malik672/uniswap-sdk-core-rust/actions/workflows/rust.yml)
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/malik672/uniswap-sdk-core-rust?logo=rust&label=CodeRabbit&color=orange)
 [![docs.rs](https://img.shields.io/docsrs/uniswap-sdk-core)](https://docs.rs/uniswap-sdk-core/latest)
 [![crates.io](https://img.shields.io/crates/v/uniswap-sdk-core.svg)](https://crates.io/crates/uniswap-sdk-core)
 
@@ -14,7 +13,7 @@ Add this to your Cargo.toml
 
 ```toml
 [dependencies]
-uniswap-sdk-core = "5.0.0"
+uniswap-sdk-core = "5.1.0"
 ```
 
 And this to your code:

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -6,21 +6,21 @@ pub type AddressMap = HashMap<u64, Address>;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct ChainAddresses {
-    v3_core_factory: Address,
-    multicall: Address,
-    quoter: Address,
-    quoter_v2: Address,
-    v3_migrator: Option<Address>,
-    nonfungible_position_manager: Address,
-    tick_lens: Option<Address>,
-    swap_router02: Option<Address>,
-    mixed_route_quoter_v1: Option<Address>,
-    mixed_route_quoter_v2: Option<Address>,
+    pub v3_core_factory: Address,
+    pub multicall: Address,
+    pub quoter: Address,
+    pub quoter_v2: Address,
+    pub v3_migrator: Option<Address>,
+    pub nonfungible_position_manager: Address,
+    pub tick_lens: Option<Address>,
+    pub swap_router02: Option<Address>,
+    pub mixed_route_quoter_v1: Option<Address>,
+    pub mixed_route_quoter_v2: Option<Address>,
 
-    v4_pool_manager: Option<Address>,
-    v4_position_manager: Option<Address>,
-    v4_state_view: Option<Address>,
-    v4_quoter: Option<Address>,
+    pub v4_pool_manager: Option<Address>,
+    pub v4_position_manager: Option<Address>,
+    pub v4_state_view: Option<Address>,
+    pub v4_quoter: Option<Address>,
 }
 
 pub const DEFAULT_NETWORKS: [ChainId; 3] = [ChainId::MAINNET, ChainId::GOERLI, ChainId::SEPOLIA];
@@ -109,6 +109,10 @@ lazy_static! {
                 ChainId::MONAD_TESTNET as u64,
                 address!("0x733e88f248b742db6c14c0b1713af5ad7fdd59d0"),
             ),
+            (
+                ChainId::SONEIUM as u64,
+                address!("0x97febbc2adbd5644ba22736e962564b23f5828ce"),
+            ),
         ])
     };
 }
@@ -168,14 +172,22 @@ lazy_static! {
                 ChainId::MONAD_TESTNET as u64,
                 address!("0xfb8e1c3b833f9e67a71c859a132cf783b645e436"),
             ),
+            (
+                ChainId::SONEIUM as u64,
+                address!("0x273f68c234fa55b550b40e563c4a488e0d334320"),
+            ),
         ])
     };
 }
 
+/// Choose not to impl `Default` for `ChainAddresses` to avoid "[E0379]: functions in trait impls
+/// cannot be declared const"
 impl ChainAddresses {
     /// Networks that share most of the same addresses i.e. Mainnet, Goerli, Optimism, Arbitrum,
     /// Polygon
-    const fn default() -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn default() -> Self {
         Self {
             v3_core_factory: address!("0x1F98431c8aD98523631AE4a59f267346ea31F984"),
             multicall: address!("0x1F98415757620B543A52E61c46B32eB19261F984"),
@@ -524,6 +536,22 @@ const MONAD_TESTNET_ADDRESSES: ChainAddresses = ChainAddresses {
     ..ChainAddresses::default()
 };
 
+const SONEIUM_ADDRESSES: ChainAddresses = ChainAddresses {
+    v3_core_factory: address!("0x42ae7ec7ff020412639d443e245d936429fbe717"),
+    multicall: address!("0x8ad5ef2f2508288d2de66f04dd883ad5f4ef62b2"),
+    quoter: address!("0x3e6c707d0125226ff60f291b6bd1404634f00aba"),
+    v3_migrator: Some(address!("0xa107580f73bd797bd8b87ff24e98346d99f93ddb")),
+    nonfungible_position_manager: address!("0x56c1205b0244332011c1e866f4ea5384eb6bfa2c"),
+    tick_lens: Some(address!("0xcd08eefb928c86499e6235ac155906bb7c4dc41a")),
+    swap_router02: Some(address!("0x7e40db01736f88464e5f4e42394f3d5bbb6705b9")),
+
+    v4_pool_manager: Some(address!("0x360e68faccca8ca495c1b759fd9eee466db9fb32")),
+    v4_position_manager: Some(address!("0x1b35d13a2e2528f192637f14b05f0dc0e7deb566")),
+    v4_state_view: Some(address!("0x76fd297e2d437cd7f76d50f01afe6160f86e9990")),
+    v4_quoter: Some(address!("0x3972c00f7ed4885e145823eb7c655375d275a1c5")),
+    ..ChainAddresses::default()
+};
+
 lazy_static! {
     /// A map of chain IDs to their corresponding Uniswap contract addresses.
     ///
@@ -559,6 +587,7 @@ lazy_static! {
             (ChainId::UNICHAIN_SEPOLIA as u64, UNICHAIN_SEPOLIA_ADDRESSES),
             (ChainId::UNICHAIN as u64, UNICHAIN_ADDRESSES),
             (ChainId::MONAD_TESTNET as u64, MONAD_TESTNET_ADDRESSES),
+            (ChainId::SONEIUM as u64, SONEIUM_ADDRESSES),
         ])
     };
 }

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -34,13 +34,14 @@ pub enum ChainId {
     UNICHAIN_SEPOLIA = 1301,
     UNICHAIN = 130,
     MONAD_TESTNET = 10143,
+    SONEIUM = 1868,
 }
 
 /// A list of `ChainId` constants representing the blockchain networks supported by the Uniswap SDK.
 ///
 /// This array includes all the `ChainId` variants that are supported by the SDK, making it easy to
 /// iterate over or check for supported chains.
-pub const SUPPORTED_CHAINS: [ChainId; 27] = [
+pub const SUPPORTED_CHAINS: [ChainId; 28] = [
     ChainId::MAINNET,
     ChainId::OPTIMISM,
     ChainId::OPTIMISM_GOERLI,
@@ -68,4 +69,5 @@ pub const SUPPORTED_CHAINS: [ChainId; 27] = [
     ChainId::UNICHAIN_SEPOLIA,
     ChainId::UNICHAIN,
     ChainId::MONAD_TESTNET,
+    ChainId::SONEIUM,
 ];

--- a/src/entities/weth9.rs
+++ b/src/entities/weth9.rs
@@ -31,9 +31,9 @@ impl WETH9 {
     #[inline]
     #[must_use]
     pub fn new() -> Self {
-        const CHAIN_IDS: [u64; 24] = [
+        const CHAIN_IDS: [u64; 25] = [
             1, 11155111, 3, 4, 5, 42, 10, 69, 11155420, 42161, 421611, 421614, 8453, 84532, 56,
-            137, 43114, 7777777, 81457, 324, 480, 1301, 130, 10143,
+            137, 43114, 7777777, 81457, 324, 480, 1301, 130, 10143, 1868,
         ];
         let tokens = HashMap::from_iter(
             CHAIN_IDS
@@ -221,6 +221,13 @@ impl WETH9 {
                 18,
                 "WMON",
                 "Wrapped Monad"
+            )),
+            1868 => Some(token!(
+                1868,
+                "0x4200000000000000000000000000000000000006",
+                18,
+                "WETH",
+                "Wrapped Ether"
             )),
             _ => None,
         }


### PR DESCRIPTION
Extended the Uniswap SDK Core with support for the Soneium chain by adding its chain ID, addresses, and relevant configurations. Adjusted `ChainAddresses` structure visibility and incremented the library version to 5.1.0 to reflect the changes. Updated README and Cargo.toml accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the SONEIUM (chain ID 1868) network, including its addresses and Wrapped Ether (WETH) token.
- **Documentation**
  - Updated the README to reflect the new version and removed the "CodeRabbit Pull Request Reviews" badge.
- **Style**
  - Improved formatting of feature definitions in configuration files for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->