### PR TITLE
fix: use uint to fix conversion of big values

### DIFF
--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -13,15 +13,12 @@ pub trait ToBig: Sized {
     #[inline]
     fn to_big_decimal(self) -> BigDecimal {
         let x = self.to_big_int();
-        BigDecimal::from_parts(
-            x.to_bits(),
-            0,
-            match x.is_negative() {
-                false => Sign::Plus,
-                true => Sign::Minus,
-            },
-            Context::default(),
-        )
+        let sign = match x.is_negative() {
+            false => Sign::Plus,
+            true => Sign::Minus,
+        };
+        let x = x.unsigned_abs();
+        BigDecimal::from_parts(x, 0, sign, Context::default())
     }
 }
 
@@ -211,5 +208,16 @@ mod tests {
         assert_eq!(x.to_big_uint(), y);
         assert_eq!(x.to_big_int(), z);
         assert_eq!(x.to_big_decimal(), x);
+    }
+
+    #[test]
+    fn test_big_to_decimal() {
+        let u = u512!(12345678901234567890123456789012345678901234567890123456789012345678);
+        let d = dec512!(12345678901234567890123456789012345678901234567890123456789012345678);
+        assert_eq!(u.to_big_decimal(), d);
+
+        let i = i512!(-12345678901234567890123456789012345678901234567890123456789012345678);
+        let d = -d;
+        assert_eq!(i.to_big_decimal(), d);
     }
 }


### PR DESCRIPTION
Updated default `to_big_decimal` implementation to use unsigned int.
This update should help with conversion of big i512 values.

Added test for this use case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved accuracy and stability when converting very large and negative numbers to decimals, ensuring correct sign and magnitude handling. Backward-compatible with no public API changes, and no action required from integrators.

- Tests
  - Added comprehensive tests covering extreme unsigned and negative values to validate conversion correctness and guard against regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->