### PR TITLE
test: add property-based fuzz tests for type conversions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Build
         run: cargo +${{ matrix.rust-version }} build
       - name: Run tests
+        env:
+          PROPTEST_CASES: 4096
         run: |
           cargo +${{ matrix.rust-version }} test
           cargo +${{ matrix.rust-version }} test --features std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]
@@ -23,6 +23,9 @@ num-integer = { version = "0.1", default-features = false }
 num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }
 regex = { version = "1.11", optional = true }
 thiserror = { version = "2", default-features = false }
+
+[dev-dependencies]
+proptest = "1"
 
 [features]
 default = []

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -16,9 +16,10 @@ pub trait ToBig: Sized {
         BigDecimal::from_parts(
             x.unsigned_abs(),
             0,
-            match x.is_negative() {
-                false => Sign::Plus,
-                true => Sign::Minus,
+            if x.is_negative() {
+                Sign::Minus
+            } else {
+                Sign::Plus
             },
             Context::default(),
         )


### PR DESCRIPTION
Add comprehensive proptest-based property tests for U256/I256 conversions to BigUint/BigInt/BigDecimal types, enhancing test coverage beyond fixed examples.

- Add proptest dev-dependency
- Implement 8 property tests covering conversion methods and round-trips
- Add edge case tests for zero, max, and signed boundary values
- Extract shared conversion helpers (biguint_from_limbs, bigint_from_limbs_unsigned, bigint_from_signed_limbs)
- Refactor existing tests to use shared helpers, reducing duplication
- Configure CI to run 4096 proptest cases for thorough coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Release
  - Bumped version to 5.2.1.
- Tests
  - Added extensive property-based tests and new edge-case coverage for numeric conversions to improve reliability.
- Refactor
  - Simplified internal test construction logic for clearer, more maintainable tests with no behavioral changes.
- Chores
  - Added a test dependency and increased CI test case count for stronger validation.

No API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->