### PR TITLE
feat: add ZERO and ONE constants to Fraction and Percent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-sdk-core"
-version = "5.2.1"
+version = "5.3.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["malik <aremumalik05@gmail.com>", "Shuhui Luo <twitter.com/aureliano_law>"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your Cargo.toml
 
 ```toml
 [dependencies]
-uniswap-sdk-core = "5.2.0"
+uniswap-sdk-core = "5.3.0"
 ```
 
 And this to your code:

--- a/src/entities/fractions/fraction.rs
+++ b/src/entities/fractions/fraction.rs
@@ -7,7 +7,7 @@ use core::{
     ops::{Add, Div, Mul, Sub},
 };
 use derive_more::Deref;
-use fastnum::{I1024, i512};
+use fastnum::I1024;
 use num_integer::Integer;
 
 /// Struct representing a fraction with metadata
@@ -25,7 +25,7 @@ impl<M: Default> Default for FractionLike<M> {
     fn default() -> Self {
         Self {
             numerator: BigInt::ZERO,
-            denominator: i512!(1),
+            denominator: BigInt::ONE,
             meta: M::default(),
         }
     }
@@ -35,6 +35,18 @@ impl<M: Default> Default for FractionLike<M> {
 pub type Fraction = FractionLike<()>;
 
 impl Fraction {
+    pub const ZERO: Fraction = Fraction {
+        numerator: BigInt::ZERO,
+        denominator: BigInt::ONE,
+        meta: (),
+    };
+
+    pub const ONE: Fraction = Fraction {
+        numerator: BigInt::ONE,
+        denominator: BigInt::ONE,
+        meta: (),
+    };
+
     /// Creates a new `Fraction` instance with the given numerator and denominator.
     ///
     /// # Arguments
@@ -328,7 +340,7 @@ mod tests {
     #[test]
     fn test_remainder() {
         assert_eq!(Fraction::new(8, 3).remainder(), Fraction::new(2, 3));
-        assert_eq!(Fraction::new(12, 4).remainder(), Fraction::default());
+        assert_eq!(Fraction::new(12, 4).remainder(), Fraction::ZERO);
         assert_eq!(Fraction::new(16, 5).remainder(), Fraction::new(1, 5));
     }
 

--- a/src/entities/fractions/percent.rs
+++ b/src/entities/fractions/percent.rs
@@ -1,9 +1,11 @@
 use crate::prelude::*;
-use lazy_static::lazy_static;
+use fastnum::i512;
 
-lazy_static! {
-    static ref ONE_HUNDRED: Fraction = Fraction::new(100, 1);
-}
+const ONE_HUNDRED: Fraction = Fraction {
+    numerator: i512!(100),
+    denominator: BigInt::ONE,
+    meta: (),
+};
 
 /// Unit struct to distinguish between a fraction and a percent
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
@@ -13,6 +15,12 @@ pub struct IsPercent;
 pub type Percent = FractionLike<IsPercent>;
 
 impl Percent {
+    pub const ZERO: Percent = Percent {
+        numerator: BigInt::ZERO,
+        denominator: BigInt::ONE,
+        meta: IsPercent,
+    };
+
     /// Constructor for creating a new [`Percent`] instance
     #[inline]
     pub fn new(numerator: impl Into<BigInt>, denominator: impl Into<BigInt>) -> Self {
@@ -27,8 +35,7 @@ impl Percent {
         significant_digits: u8,
         rounding: Option<Rounding>,
     ) -> Result<String, Error> {
-        (self.as_fraction() * ONE_HUNDRED.as_fraction())
-            .to_significant(significant_digits, rounding)
+        (self.as_fraction() * ONE_HUNDRED).to_significant(significant_digits, rounding)
     }
 
     /// Converts the [`Percent`] to a string with a fixed number of decimal places and rounding
@@ -36,7 +43,7 @@ impl Percent {
     #[inline]
     #[must_use]
     pub fn to_fixed(&self, decimal_places: u8, rounding: Option<Rounding>) -> String {
-        (self.as_fraction() * ONE_HUNDRED.as_fraction()).to_fixed(decimal_places, rounding)
+        (self.as_fraction() * ONE_HUNDRED).to_fixed(decimal_places, rounding)
     }
 }
 


### PR DESCRIPTION
- Add Fraction::ZERO and Fraction::ONE constants
- Add Percent::ZERO constant
- Refactor Default impl to use BigInt::ONE
- Replace lazy_static ONE_HUNDRED with const
- Use constants in tests for better semantic clarity
- Remove unused i512 import from fraction.rs
- Bump version to 5.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added built-in zero and one constants for fractions for easier initialization and comparisons.
  - Added a built-in zero constant for percentages.
- Documentation
  - Updated README to reference the latest dependency version.
- Chores
  - Bumped package version to 5.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->